### PR TITLE
Use `workspace.dependencies` to uniformly manage the dependent versions of all packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,32 +149,33 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -406,9 +407,9 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.24",
+ "rustix 0.37.27",
  "slab",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "waker-fn",
 ]
 
@@ -429,18 +430,18 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -547,9 +548,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -559,9 +560,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
 dependencies = [
  "serde",
 ]
@@ -612,9 +613,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -743,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
+checksum = "ca548b6163b872067dc5eb82fd130c56881435e30367d2073594a3d9744120dd"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -761,9 +762,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "serde",
@@ -851,7 +852,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -1184,25 +1185,24 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.3.0",
+ "cipher 0.4.4",
  "cpufeatures",
- "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead 0.4.3",
+ "aead 0.5.2",
  "chacha20",
- "cipher 0.3.0",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -1260,6 +1260,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1284,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1294,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1306,21 +1307,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "codespan-reporting"
@@ -1477,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -1594,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1670,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -1766,7 +1767,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms 3.1.2",
+ "platforms 3.2.0",
  "rustc_version 0.4.0",
  "subtle",
  "zeroize",
@@ -1774,20 +1775,20 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.107"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe98ba1789d56fb3db3bee5e032774d4f421b685de7ba703643584ba24effbe"
+checksum = "7129e341034ecb940c9072817cd9007974ea696844fc4dd582dc1653a7fbe2e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1797,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.107"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ce20f6b8433da4841b1dadfb9468709868022d829d5ca1f2ffbda928455ea3"
+checksum = "a2a24f3f5f8eed71936f21e570436f024f5c2e25628f7496aa7ccd03b90109d5"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1807,24 +1808,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.107"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20888d9e1d2298e2ff473cee30efe7d5036e437857ab68bbfea84c74dba91da2"
+checksum = "06fdd177fc61050d63f67f5bd6351fac6ab5526694ea8e359cd9cd3b75857f44"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.107"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa16a70dd58129e4dfffdff535fb1bce66673f7bbeec4a5a1765a504e1ccd84"
+checksum = "587663dd5fb3d10932c8aecfe7c844db1bcf0aee93eeab08fac13dc1212c2e7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1939,9 +1940,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive-syn-parse"
@@ -2087,7 +2091,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2143,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
@@ -2184,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
  "signature 2.1.0",
@@ -2213,7 +2217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek 4.1.1",
- "ed25519 2.2.2",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
@@ -2272,7 +2276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.4",
  "digest 0.10.7",
  "ff 0.13.0",
  "generic-array 0.14.7",
@@ -2304,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -2329,23 +2333,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2714,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -2776,9 +2769,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -3037,7 +3030,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3152,7 +3145,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3164,7 +3157,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3174,7 +3167,7 @@ source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3269,9 +3262,12 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+checksum = "fb5fd9bcbe8b1087cbd395b51498c01bc997cef73e778a80b77a811af5e2d29f"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs2"
@@ -3289,7 +3285,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.38.17",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
@@ -3301,9 +3297,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3316,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3326,15 +3322,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3355,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -3376,13 +3372,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3393,20 +3389,20 @@ checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
  "rustls 0.20.9",
- "webpki 0.22.2",
+ "webpki 0.22.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-timer"
@@ -3416,9 +3412,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3484,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3592,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39b3bc2a8f715298032cf5087e58573809374b08160aa7d750582bdb82d2683"
+checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
 dependencies = [
  "log",
  "pest",
@@ -3631,7 +3627,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -3640,16 +3636,16 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "allocator-api2",
 ]
 
@@ -3659,7 +3655,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -3769,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -3830,7 +3826,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.13",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3854,33 +3850,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "log",
- "rustls 0.21.7",
+ "rustls 0.21.8",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots 0.23.1",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.48.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3897,7 +3893,7 @@ name = "ic-verify-bls-signature"
 version = "0.2.0"
 dependencies = [
  "bls12_381",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "hex",
  "lazy_static",
  "pairing",
@@ -3944,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9465340214b296cd17a0009acdb890d6160010b8adf8f78a00d0d7ab270f79f"
+checksum = "bbb892e5777fe09e16f3d44de7802f4daa7267ecbe8c466f19d94e25bb0c303e"
 dependencies = [
  "async-io",
  "core-foundation",
@@ -3958,7 +3954,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows 0.34.0",
+ "windows",
 ]
 
 [[package]]
@@ -4012,12 +4008,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -4108,7 +4104,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4116,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -4127,7 +4123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.17",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
@@ -4157,18 +4153,18 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4245,7 +4241,7 @@ checksum = "7e5f9fabdd5d79344728521bb65e3106b49ec405a78b66fbff073b72b389fa43"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls 0.24.1",
+ "hyper-rustls 0.24.2",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustc-hash",
@@ -4389,9 +4385,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -4418,7 +4414,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
  "instant",
  "libp2p-core 0.38.0",
  "libp2p-dns",
@@ -4600,7 +4596,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "trust-dns-proto",
  "void",
@@ -4761,7 +4757,7 @@ dependencies = [
  "libc",
  "libp2p-core 0.38.0",
  "log",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
 ]
 
@@ -4779,7 +4775,7 @@ dependencies = [
  "ring 0.16.20",
  "rustls 0.20.9",
  "thiserror",
- "webpki 0.22.2",
+ "webpki 0.22.4",
  "x509-parser 0.14.0",
  "yasna",
 ]
@@ -4860,6 +4856,17 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -4994,15 +5001,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -5120,7 +5127,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.17",
+ "rustix 0.38.24",
 ]
 
 [[package]]
@@ -5194,9 +5201,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5642,7 +5649,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5710,11 +5717,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5731,7 +5738,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5742,9 +5749,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",
@@ -6097,7 +6104,7 @@ source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -6267,7 +6274,6 @@ dependencies = [
  "pallet-tee-worker",
  "pallet-timestamp",
  "parity-scale-codec",
- "parking_lot 0.11.2",
  "rand_chacha 0.2.2",
  "scale-info",
  "serde",
@@ -6588,7 +6594,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -6735,9 +6741,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab512a34b3c2c5e465731cc7668edf79208bbe520be03484eeb05e63ed221735"
+checksum = "59e9ab494af9e6e813c72170f0d3c1de1500990d62c97cc05cc7576f91aa402f"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -6794,9 +6800,9 @@ checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -6816,7 +6822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -6835,13 +6841,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -6902,9 +6908,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6913,9 +6919,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6923,22 +6929,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
@@ -6952,7 +6958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -6972,7 +6978,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7039,9 +7045,9 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "platforms"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "polling"
@@ -7061,13 +7067,13 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug 0.3.0",
- "universal-hash 0.4.1",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -7096,9 +7102,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -7158,9 +7170,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -7212,14 +7224,14 @@ checksum = "0e99670bafb56b9a106419397343bdbc8b8742c3cc449fec6345f86173f47cd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -7365,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956be1b23f4261676aed05a0046e204e8a6836e50203902683a718af0797989"
+checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -7378,7 +7390,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.2",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -7455,7 +7467,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -7546,13 +7558,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom 0.2.11",
+ "libredox",
  "thiserror",
 ]
 
@@ -7573,7 +7594,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7590,14 +7611,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -7611,13 +7632,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -7628,9 +7649,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "region"
@@ -7682,7 +7703,7 @@ dependencies = [
  "cc",
  "libc",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "which 3.1.1",
  "winapi",
 ]
@@ -7697,9 +7718,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7745,13 +7780,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.2.0"
+version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
 dependencies = [
  "libc",
  "rtoolbox",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7802,12 +7837,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7857,7 +7892,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -7871,9 +7906,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.15"
+version = "0.36.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
+checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -7885,9 +7920,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.24"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -7899,14 +7934,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.8",
+ "linux-raw-sys 0.4.11",
  "windows-sys 0.48.0",
 ]
 
@@ -7931,20 +7966,20 @@ checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring 0.16.20",
- "sct 0.7.0",
- "webpki 0.22.2",
+ "sct 0.7.1",
+ "webpki 0.22.4",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring 0.16.20",
- "rustls-webpki 0.101.6",
- "sct 0.7.0",
+ "ring 0.17.5",
+ "rustls-webpki",
+ "sct 0.7.1",
 ]
 
 [[package]]
@@ -7961,31 +7996,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.3"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.16.20",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
-dependencies = [
- "ring 0.16.20",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8142,7 +8167,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -8345,7 +8370,7 @@ name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
 source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9.42#48fb01c12d4cdb22c6a71f3b9b387b01e30f0ff9"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "array-bytes",
  "async-trait",
  "dyn-clone",
@@ -8517,7 +8542,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "rustix 0.36.15",
+ "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -8654,7 +8679,7 @@ name = "sc-network-gossip"
 version = "0.10.0-dev"
 source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9.42#48fb01c12d4cdb22c6a71f3b9b387b01e30f0ff9"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "futures",
  "futures-timer",
  "libp2p",
@@ -9057,7 +9082,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -9118,9 +9143,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9132,9 +9157,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9157,7 +9182,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -9199,17 +9224,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring 0.16.20",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.16.20",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9322,9 +9347,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -9337,29 +9362,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -9368,9 +9393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -9525,9 +9550,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "snap"
@@ -9537,16 +9562,16 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
+checksum = "58021967fd0a5eeeb23b08df6cc244a4d4a5b4aec1d27c9e02fad1a58b4cd74e"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm 0.10.3",
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
- "ring 0.16.20",
+ "ring 0.17.5",
  "rustc_version 0.4.0",
  "sha2 0.10.8",
  "subtle",
@@ -9554,9 +9579,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -9564,9 +9589,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -9620,7 +9645,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -9843,7 +9868,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -9862,7 +9887,7 @@ source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10073,7 +10098,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10198,7 +10223,7 @@ name = "sp-trie"
 version = "7.0.0"
 source = "git+https://github.com/CESSProject/substrate?branch=cess-polkadot-v0.9.42#48fb01c12d4cdb22c6a71f3b9b387b01e30f0ff9"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "hash-db 0.16.0",
  "hashbrown 0.13.2",
  "lazy_static",
@@ -10241,7 +10266,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10347,7 +10372,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6753e460c998bbd4cd8c6f0ed9a64346fcca0723d6e75e52fdc351c5d2169d"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "atoi",
  "byteorder",
  "bytes",
@@ -10363,7 +10388,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "memchr",
  "native-tls",
@@ -10442,9 +10467,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6915280e2d0db8911e5032a5c275571af6bdded2916abd691a659be25d3439"
+checksum = "35935738370302d5e33963665b77541e4b990a3e919ec904c837a56cfc891de1"
 dependencies = [
  "Inflector",
  "num-format",
@@ -10544,9 +10569,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eee6965196b32f882dd2ee85a92b1dbead41b04e53907f269de3b0dc04733c"
+checksum = "e620c7098893ba667438b47169c00aacdd9e7c10e042250ce2b60b087ec97328"
 dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
@@ -10644,7 +10669,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10692,9 +10717,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10742,28 +10767,28 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall 0.3.5",
- "rustix 0.38.17",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -10776,22 +10801,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10831,12 +10856,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -10912,9 +10938,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10924,20 +10950,20 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.13",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -10948,7 +10974,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.9",
  "tokio",
- "webpki 0.22.2",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -10957,7 +10983,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls 0.21.8",
  "tokio",
 ]
 
@@ -10975,9 +11001,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -11011,9 +11037,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -11024,7 +11050,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -11074,11 +11100,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite 0.2.13",
  "tracing-attributes",
@@ -11087,20 +11112,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11118,12 +11143,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -11210,7 +11235,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -11441,6 +11466,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11459,11 +11490,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -11538,9 +11569,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -11548,24 +11579,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -11575,9 +11606,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11585,22 +11616,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-instrument"
@@ -11808,7 +11839,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.36.15",
+ "rustix 0.36.17",
  "serde",
  "sha2 0.10.8",
  "toml 0.5.11",
@@ -11888,7 +11919,7 @@ checksum = "eed41cbcbf74ce3ff6f1d07d1b707888166dc408d1a880f651268f4f7c9194b2"
 dependencies = [
  "object 0.29.0",
  "once_cell",
- "rustix 0.36.15",
+ "rustix 0.36.17",
 ]
 
 [[package]]
@@ -11919,7 +11950,7 @@ dependencies = [
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.15",
+ "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -11940,9 +11971,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11954,7 +11985,7 @@ version = "0.21.0"
 dependencies = [
  "ring 0.16.20",
  "ring 0.16.9",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -11964,17 +11995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring 0.16.20",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "webpki"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.16.20",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -11983,16 +12014,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.3",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -12128,7 +12150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
 dependencies = [
  "log",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "thiserror",
  "tokio",
  "webrtc-util",
@@ -12228,14 +12250,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.17",
+ "rustix 0.38.24",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebecebefc38ff1860b4bc47550bbfa63af5746061cf0d29fcd7fa63171602598"
+checksum = "c68938b57b33da363195412cfc5fc37c9ed49aa9cfe2156fde64b8d2c9498242"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -12280,22 +12302,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.34.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
+ "windows-core",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]
@@ -12377,12 +12396,6 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -12392,12 +12405,6 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12413,12 +12420,6 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -12428,12 +12429,6 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -12461,12 +12456,6 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
@@ -12479,9 +12468,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -12595,6 +12584,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12611,7 +12620,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -12654,11 +12663,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,204 @@ inherits = "release"
 lto = "fat"
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1
+
+
+[workspace.dependencies]
+# ---- Substrate crates begin ----
+#	primitives
+sp-core = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+# sp-core-hashing = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-runtime = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-runtime-interface = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-keyring = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-blockchain = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-std = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-io = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-application-crypto = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+# sp-consensus-babe = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-externalities = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-authority-discovery = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-timestamp = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-inherents = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-consensus = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-transaction-storage-proof = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-keystore = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-state-machine = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-tracing = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-trie = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-block-builder = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-offchain = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-staking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-session = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-transaction-pool = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-version = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-npos-elections = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+node-primitives = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+cessp-consensus-rrsc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+
+#	frames
+frame-support = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-system = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-benchmarking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-executive = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-election-provider-support = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-try-runtime = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+frame-support-test = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42"  }
+
+#	pallets
+pallet-assets = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-asset-tx-payment = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-contracts-primitives = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-democracy = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-uniques = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-preimage = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-balances = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-timestamp = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-scheduler = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-collective = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-contracts = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-im-online = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-sudo = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-treasury = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-authorship = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+# pallet-babe = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-bags-list = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-bounties = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-child-bounties = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-grandpa = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-indices = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-identity = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-lottery = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-membership = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-multisig = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-mmr = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-nomination-pools-benchmarking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-offences = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-offences-benchmarking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-proxy = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-recovery = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-session = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false, features = ["historical"] }
+pallet-session-benchmarking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+# pallet-staking = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-society = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-tips = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-utility = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-vesting = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-rrsc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+
+#	client dependencies
+sc-client-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-transaction-pool-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-network-common = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-chain-spec = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-transaction-pool = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-offchain = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-network = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-network-sync = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-slots = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-babe = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-basic-authorship = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-service = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-telemetry = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-authority-discovery = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-sync-state-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-sysinfo = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-block-builder = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-client-db = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-epochs = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-service-test = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-keystore = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-cli = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-executor = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-babe-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-grandpa = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+grandpa = { package = "sc-consensus-grandpa", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-grandpa-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-rpc-api = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-consensus-manual-seal = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-rpc-spec-v2 = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+cessc-consensus-rrsc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+cessc-consensus-rrsc-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+cessc-sync-state-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+
+substrate-state-trie-migration-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+substrate-wasm-builder = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42"  }
+node-inspect = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+try-runtime-cli = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+substrate-frame-cli = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+substrate-build-script-utils = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+substrate-rpc-client = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+substrate-frame-rpc-system = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+mmr-rpc = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+substrate-test-utils = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+# ---- Substrate crates end ----
+
+# ---- Frontier crates begin ----
+fp-account = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fp-evm = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fp-rpc = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fp-self-contained = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+
+pallet-base-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-ethereum = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-evm = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+
+fc-cli = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-consensus = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-db = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-mapping-sync = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-rpc = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-rpc-core = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-storage = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+# ---- Frontier crates end ----
+
+array-bytes = "4.1"
+anyhow = { version = "1", default-features = false }
+async-trait = "0.1"
+base64 = { version = "0.12", default-features = false, features = ["alloc"] }
+bls12_381 = { version = "0.7", default-features = false, features = ["groups", "pairings", "alloc", "experimental"] }
+clap = { version = "4.0.32", features = ["derive"] }
+futures = "0.3"
+getrandom = { version = "0.2.10", default-features = false, features = ["custom"] }
+hex-literal = "0.4.1"
+hex = { version = "0.4", default-features = false }
+jsonrpsee = { version = "0.16" }  # this version of jsonrpsee is used by Substrate's crates
+lazy_static = { version = "1", default-features = false }
+libc = "0.2"
+log = { version = "0.4", default-features = false }
+parity-scale-codec = { version = "3.2.2", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
+pairing = { version = "0.22", default-features = false }
+rand = "0.8.5"
+rand_chacha = { version = "0.2", default-features = false }
+rsa = { version = "0.8.2", default-features = false }
+scale-info = { version = "2.5", default-features = false }
+serde_json = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false }
+sha2 = { version = "0.9", default-features = false }

--- a/c-pallets/audit/Cargo.toml
+++ b/c-pallets/audit/Cargo.toml
@@ -11,12 +11,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# serde = { version = "1.0.136", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-log = { version = "0.4.14", default-features = false }
+# serde = { workspace = true, optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
+log = { workspace = true }
 pallet-cess-staking = { path = '../staking', version = '4.0.0-dev', default-features = false }
-pallet-preimage = { version = "4.0.0-dev", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
+pallet-preimage = { workspace = true }
 
 # local pallet
 cp-bloom-filter = { path = '../../primitives/bloom-filter', default-features = false }
@@ -25,106 +25,43 @@ cp-cess-common = { path = '../../primitives/common', default-features = false }
 cp-enclave-verify = { path = '../../primitives/enclave-verify', default-features = false }
 pallet-cess-treasury = { default-features = false, path = "../cess-treasury" }
 
-[dependencies.frame-benchmarking]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-optional = true
+frame-benchmarking = { workspace = true, optional = true }
 
-[dependencies.frame-support]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-support = { workspace = true }
 
-[dependencies.frame-system]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-system = { workspace = true }
 
-[dependencies.sp-io]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-io = { workspace = true }
 
-[dependencies.sp-std]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '5.0.0'
+sp-std = { workspace = true }
 
-[dependencies.pallet-balances]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-balances = { workspace = true }
 
-[dependencies.sp-core]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-core = { workspace = true }
 
-[dev-dependencies.pallet-timestamp]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-timestamp = { workspace = true }
 
-[dependencies.sp-runtime]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-runtime = { workspace = true }
 
 # local dependencies
-[dependencies.pallet-file-bank]
-default-features = false
-path = '../file-bank'
-
+pallet-file-bank = { default-features = false, path = '../file-bank' }
 # local dependencies
-[dependencies.pallet-sminer]
-default-features = false
-path = '../sminer'
-
+pallet-sminer = { default-features = false, path = '../sminer' }
 # local dependencies
-[dependencies.pallet-tee-worker]
-default-features = false
-path = '../tee-worker'
-
+pallet-tee-worker = { default-features = false, path = '../tee-worker' }
 # local dependencies
-[dependencies.pallet-storage-handler]
-default-features = false
-path = '../storage-handler'
-
-[dev-dependencies.frame-support-test]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '3.0.0'
-
-[dev-dependencies.pallet-balances]
-#default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-
-[dev-dependencies.pallet-scheduler]
-#default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-storage-handler = { default-features = false, path = '../storage-handler' }
 
 [dev-dependencies]
+frame-support-test = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-scheduler = { workspace = true }
 pallet-cess-staking = { path = '../staking', version = '4.0.0-dev', default-features = false}
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-npos-elections = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-session = { version = "4.0.0-dev", default-features = false,  git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bags-list = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sp-staking = { workspace = true }
+sp-npos-elections = { workspace = true }
+frame-election-provider-support = { workspace = true }
+pallet-session = { workspace = true }
+pallet-bags-list = { workspace = true }
 pallet-scheduler-credit = { default-features = false, path = '../scheduler-credit'}
 cp-cess-common = { path = '../../primitives/common', default-features = false }
 pallet-oss = { path = '../oss', default-features = false }

--- a/c-pallets/cacher/Cargo.toml
+++ b/c-pallets/cacher/Cargo.toml
@@ -4,22 +4,22 @@ version = "0.7.0"
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-benchmarking = { version = '4.0.0-dev', default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42', optional = true}
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true}
 
 #local dependencies
 cp-cess-common = { path = '../../primitives/common', default-features = false }
 
 [dev-dependencies]
-sp-core = {version = '7.0.0', git = 'https://github.com/CESSProject/substrate', default-features = false, branch = 'cess-polkadot-v0.9.42'}
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-io = {version = '7.0.0', git = 'https://github.com/CESSProject/substrate', default-features = false, branch = 'cess-polkadot-v0.9.42'}
+sp-core = { workspace = true }
+pallet-balances = { workspace = true }
+sp-io = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/cess-treasury/Cargo.toml
+++ b/c-pallets/cess-treasury/Cargo.toml
@@ -9,14 +9,14 @@ description = "FRAME pallet for sminer management"
 readme = "README.md"
 
 [dependencies]
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
 
 #substrate pallet
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-std = { version = "5.0.0", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-runtime = { version = "7.0.0", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
 
 
 [features]

--- a/c-pallets/file-bank/Cargo.toml
+++ b/c-pallets/file-bank/Cargo.toml
@@ -11,93 +11,58 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parking_lot = "0.11"
-serde = { version = "1.0.136", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }
-log = { version = "0.4.14", default-features = false }
+# parking_lot = "0.11"
+serde = { workspace = true, optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ['alloc'] }
+log = { workspace = true }
+rand_chacha = { workspace = true, optional = true }
+pallet-rrsc = { workspace = true }
+pallet-grandpa = { workspace = true }
+
 pallet-cess-staking = { path = '../staking', version = '4.0.0-dev', default-features = false }
-rand_chacha = { version = "0.2", default-features = false, optional = true }
 cp-scheduler-credit = { path = '../../primitives/scheduler-credit', version = '0.1.0', default-features = false }
 cp-cess-common = { path = '../../primitives/common', version = '0.1.0', default-features = false }
 cp-enclave-verify = { path = '../../primitives/enclave-verify', version = '0.1.0', default-features = false }
 pallet-oss = { path = '../oss', version = '0.7.0', default-features = false }
-pallet-rrsc = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
- # cessp-consensus-rrsc = { version = "0.10.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
 
 # substrate pallet
-pallet-scheduler = { version = '4.0.0-dev', git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-# sc-network = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-scheduler = { workspace = true }
+# sc-network = { workspace = true }
 
 # local dependencies
 pallet-sminer = { default-features = false, path = '../sminer' }
 pallet-tee-worker = { default-features = false, path = '../tee-worker' }
 pallet-storage-handler = { default-features = false, path = '../storage-handler' }
 
-[dependencies.frame-benchmarking]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-optional = true
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 
-[dependencies.frame-support]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+sp-io = { workspace = true }
 
-[dependencies.frame-system]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+sp-std = { workspace = true }
 
-[dependencies.sp-io]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+pallet-balances = { workspace = true }
 
-[dependencies.sp-std]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '5.0.0'
+sp-core = { workspace = true }
 
-[dependencies.pallet-balances]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-
-[dependencies.sp-core]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
-
-[dependencies.sp-runtime]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-runtime = { workspace = true }
 
 # dev dependencies
 [dev-dependencies]
 pallet-cess-staking = { path = '../staking', version = '4.0.0-dev', default-features = false}
-frame-support-test = { git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '3.0.0' }
-pallet-scheduler = { git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '4.0.0-dev' }
-pallet-timestamp = { git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '4.0.0-dev' }
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-npos-elections = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-session = { version = "4.0.0-dev", default-features = false,  git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bags-list = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+frame-support-test = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-staking = { workspace = true }
+sp-npos-elections = { workspace = true }
+frame-election-provider-support = { workspace = true }
+pallet-session = { workspace = true }
+pallet-bags-list = { workspace = true }
 pallet-scheduler-credit = { version = "0.1.0", default-features = false, path = '../scheduler-credit'}
-pallet-preimage = { version = "4.0.0-dev", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
+pallet-preimage = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/oss/Cargo.toml
+++ b/c-pallets/oss/Cargo.toml
@@ -4,22 +4,22 @@ version = "0.7.0"
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-benchmarking = { version = '4.0.0-dev', default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", optional = true}
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true}
 
 #local dependencies
 cp-cess-common = { path = '../../primitives/common', default-features = false }
 
 [dev-dependencies]
-sp-core = {version = '7.0.0', git = 'https://github.com/CESSProject/substrate', default-features = false, branch = "cess-polkadot-v0.9.42"}
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-io = {version = '7.0.0', git = 'https://github.com/CESSProject/substrate', default-features = false, branch = "cess-polkadot-v0.9.42"}
+sp-core = { workspace = true }
+pallet-balances = { workspace = true }
+sp-io = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/scheduler-credit/Cargo.toml
+++ b/c-pallets/scheduler-credit/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 
 #lock dependencies
 cp-scheduler-credit = { default-features = false, path = '../../primitives/scheduler-credit' }
 
 [dev-dependencies]
-sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sp-io = { workspace = true }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/sminer/Cargo.toml
+++ b/c-pallets/sminer/Cargo.toml
@@ -11,13 +11,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-serde = { version = "1.0.136", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-rand_chacha = { version = "0.2", default-features = false, optional = true }
-pallet-preimage = { version = "4.0.0-dev", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
-
+log = { workspace = true }
+serde = { workspace = true, optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+rand_chacha = { workspace = true, optional = true }
+pallet-preimage = { workspace = true }
 
 #local crate
 pallet-tee-worker = { default-features = false, path = '../tee-worker' }
@@ -28,76 +27,29 @@ cp-enclave-verify = { path = '../../primitives/enclave-verify', default-features
 cp-bloom-filter = { path = '../../primitives/bloom-filter', default-features = false }
 cp-cess-common = { path = '../../primitives/common', default-features = false }
 
-[dependencies.frame-benchmarking]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-optional = true
+frame-benchmarking = { workspace = true, optional = true }
 
-[dependencies.frame-support]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-support = { workspace = true }
 
-[dependencies.frame-system]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-system = { workspace = true }
 
-[dependencies.sp-io]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-io = { workspace = true }
 
-[dependencies.sp-std]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '5.0.0'
+sp-std = { workspace = true }
 
-[dependencies.pallet-balances]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-balances = { workspace = true }
 
-[dependencies.pallet-timestamp]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-timestamp = { workspace = true }
 
-[dependencies.sp-core]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-core = { workspace = true }
 
-[dependencies.sp-runtime]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-runtime = { workspace = true }
 
-[dependencies.pallet-scheduler]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+pallet-scheduler = { workspace = true }
 
-[dev-dependencies.pallet-scheduler]
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-
-[dev-dependencies.pallet-balances]
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+[dev-dependencies]
+pallet-scheduler = { workspace = true }
+pallet-balances = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/staking/Cargo.toml
+++ b/c-pallets/staking/Cargo.toml
@@ -13,39 +13,37 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-serde = { version = "1.0.136", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
-	"derive",
-] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-session = { version = "4.0.0-dev", features = [ "historical" ], default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-authorship = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-application-crypto = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-log = { version = "0.4.14", default-features = false }
+serde = { workspace = true, optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+sp-std = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-session = { workspace = true, features = [ "historical" ] }
+pallet-authorship = { workspace = true }
+sp-application-crypto = { workspace = true }
+frame-election-provider-support = { workspace = true }
+log = { workspace = true }
 
 # Optional imports for benchmarking
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", optional = true }
-rand_chacha = { version = "0.2", default-features = false, optional = true }
+frame-benchmarking = { workspace = true, optional = true }
+rand_chacha = { workspace = true, optional = true }
 
 [dev-dependencies]
-sp-tracing = { version = "6.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-npos-elections = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-staking-reward-curve = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bags-list = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-substrate-test-utils = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-rand_chacha = { version = "0.2" }
+sp-tracing = { workspace = true }
+sp-core = { workspace = true }
+sp-npos-elections = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-staking-reward-curve = { workspace = true }
+pallet-bags-list = { workspace = true }
+substrate-test-utils = { workspace = true }
+frame-benchmarking = { workspace = true }
+frame-election-provider-support = { workspace = true }
+rand_chacha = { workspace = true }
 
 [features]
 default = ["std"]

--- a/c-pallets/storage-handler/Cargo.toml
+++ b/c-pallets/storage-handler/Cargo.toml
@@ -9,21 +9,21 @@ description = "FRAME pallet for sminer management"
 readme = "README.md"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-serde = { version = "1.0.136", optional = true }
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true, optional = true }
 
 # substrate pallet
-frame-support = { version = "4.0.0-dev", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-frame-system = { version = "4.0.0-dev", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-frame-benchmarking = { version = '4.0.0-dev', git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-balances = { version = "4.0.0-dev", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-benchmarking = { workspace = true }
+pallet-balances = { workspace = true }
 
 # substrate primitives 
-sp-core = { version = "7.0.0", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-std = { version = "5.0.0", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-runtime = { version = "7.0.0", git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", default-features = false }
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-runtime = { workspace = true }
 
 # local dependencies
 cp-cess-common = { path = '../../primitives/common', default-features = false }

--- a/c-pallets/tee-worker/Cargo.toml
+++ b/c-pallets/tee-worker/Cargo.toml
@@ -9,69 +9,42 @@ description = "FRAME pallet for TEE Worker management"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.136", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { default-features = false, features = ['derive'], version = "2.0.1" }
-serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }
-log = { version = "0.4.14", default-features = false }
-sp-io = { version = "7.0.0", default-features = false, branch = 'cess-polkadot-v0.9.42', git = 'https://github.com/CESSProject/substrate' }
+serde = { workspace = true, optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ['derive'] }
+serde_json = { workspace = true, features = ['alloc'] }
+log = { workspace = true }
+sp-io = { workspace = true }
 
 # local dependencies
 cp-cess-common = { path = '../../primitives/common', default-features = false }
 cp-scheduler-credit = { path = '../../primitives/scheduler-credit', default-features = false }
 cp-enclave-verify = { path = '../../primitives/enclave-verify', default-features = false }
 
-[dependencies.frame-benchmarking]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
-optional = true
+frame-benchmarking = { workspace = true, optional = true }
 
-[dependencies.frame-support]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-support = { workspace = true }
 
-[dependencies.frame-system]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '4.0.0-dev'
+frame-system = { workspace = true }
 
-[dependencies.sp-std]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '5.0.0'
+sp-std = { workspace = true }
 
-[dependencies.sp-core]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-core = { workspace = true }
 
-[dependencies.sp-runtime]
-default-features = false
-git = 'https://github.com/CESSProject/substrate'
-branch = "cess-polkadot-v0.9.42"
-version = '7.0.0'
+sp-runtime = { workspace = true }
 
-[dependencies.pallet-cess-staking]
-default-features = false
-path = '../staking'
-version = '4.0.0-dev'
+pallet-cess-staking = { default-features = false, path = "../staking" }
+
 
 [dev-dependencies]
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-npos-elections = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bags-list = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-scheduler-credit = { version = "0.1.0", default-features = false, path = '../scheduler-credit'}
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-staking = { workspace = true }
+sp-npos-elections = { workspace = true }
+frame-election-provider-support = { workspace = true }
+pallet-session = { workspace = true }
+pallet-bags-list = { workspace = true }
+pallet-scheduler-credit = { default-features = false, path = '../scheduler-credit'}
 
 
 [features]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,109 +16,109 @@ name = "cess-node"
 
 [dependencies]
 # third-party dependencies
-array-bytes = "4.1"
-async-trait = "0.1"
-clap = { version = "4.0.9", features = ["derive"], optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0" }
-serde = { version = "1.0.136", features = ["derive"] }
-jsonrpsee = { version = "0.16.2", features = ["server"] }
-futures = { version = "0.3.28", features = ["thread-pool"]}	
-log = "0.4.17"
-rand = "0.8"
+array-bytes = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true, features = ["derive"], optional = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+jsonrpsee = { workspace = true, features = ["server"] }
+futures = { workspace = true, features = ["thread-pool"]}	
+log = { workspace = true }
+rand = { workspace = true }
 
 # primitives
-# sp-authorship = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-api = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-authority-discovery = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-cessp-consensus-rrsc = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-keyring = { version = "7.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-keystore = { version = "0.13.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-transaction-storage-proof = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-session = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
-sp-trie = { version = "7.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
+# sp-authorship = { workspace = true }
+sp-api = { workspace = true }
+sp-authority-discovery = { workspace = true }
+sp-core = { workspace = true }
+sp-consensus = { workspace = true }
+cessp-consensus-rrsc = { workspace = true }
+sp-consensus-grandpa = { workspace = true }
+sp-runtime = { workspace = true }
+sp-timestamp = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-inherents = { workspace = true }
+sp-keyring = { workspace = true }
+sp-keystore = { workspace = true }
+sp-transaction-storage-proof = { workspace = true }
+sp-offchain = { workspace = true }
+sp-session = { workspace = true }
+sp-trie = { workspace = true }
 
 # client dependencies
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-cessc-consensus-rrsc = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-# sc-consensus-uncles = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-grandpa = { version = "0.10.0-dev", package = "sc-consensus-grandpa", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-authority-discovery = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-cessc-sync-state-rpc = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-sysinfo = { version = "6.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sc-client-api = { workspace = true }
+sc-chain-spec = { workspace = true }
+sc-consensus = { workspace = true }
+sc-consensus-manual-seal = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sc-network = { workspace = true }
+sc-network-common = { workspace = true }
+sc-network-sync = { workspace = true }
+sc-consensus-slots = { workspace = true }
+cessc-consensus-rrsc = { workspace = true }
+# sc-consensus-uncles = { workspace = true }
+grandpa = { workspace = true }
+sc-rpc = { workspace = true }
+sc-basic-authorship = { workspace = true }
+sc-service = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-executor = { workspace = true }
+sc-authority-discovery = { workspace = true }
+cessc-sync-state-rpc = { workspace = true }
+sc-sysinfo = { workspace = true }
+prometheus-endpoint = { workspace = true }
 
 # frame dependencies
-frame-system = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-im-online = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-im-online = { workspace = true }
 
 # node-specific dependencies
 cess-node-runtime = { path = "../runtime" }
 
 # CLI-specific dependencies
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-try-runtime-cli = { version = "0.10.0-dev", optional = true, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-serde_json = "1.0.85"
+sc-cli = { workspace = true }
+frame-benchmarking-cli = { workspace = true }
+try-runtime-cli = { workspace = true, optional = true }
+serde_json = { workspace = true }
 
 # Other
 
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-mmr-rpc = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-substrate-state-trie-migration-rpc = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-rpc-spec-v2 = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-audit = { version = "0.7.0", default-features = false, path = "../c-pallets/audit" }
-sc-consensus-grandpa-rpc = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-cessc-consensus-rrsc-rpc = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sc-consensus-epochs = { version = "0.10.0-dev", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-contracts = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+frame-benchmarking = { workspace = true }
+mmr-rpc = { workspace = true }
+substrate-state-trie-migration-rpc = { workspace = true }
+sc-keystore = { workspace = true }
+sc-rpc-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-blockchain = { workspace = true }
+substrate-frame-rpc-system = { workspace = true }
+sc-rpc-spec-v2 = { workspace = true }
+pallet-audit = { default-features = false, path = "../c-pallets/audit" }
+sc-consensus-grandpa-rpc = { workspace = true }
+cessc-consensus-rrsc-rpc = { workspace = true }
+sc-consensus-epochs = { workspace = true }
+pallet-contracts = { workspace = true }
 
 # Frontier
-fc-cli = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-consensus = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-db = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-mapping-sync = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-rpc = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-rpc-core = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fc-storage = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-account = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-evm = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-rpc = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fc-cli = { workspace = true }
+fc-consensus = { workspace = true }
+fc-db = { workspace = true }
+fc-mapping-sync = { workspace = true }
+fc-rpc = { workspace = true }
+fc-rpc-core = { workspace = true }
+fc-storage = { workspace = true }
+fp-account = { workspace = true }
+fp-dynamic-fee = { workspace = true }
+fp-evm = { workspace = true }
+fp-rpc = { workspace = true }
 
 [build-dependencies]
-try-runtime-cli = { version = "0.10.0-dev", optional = true , git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+try-runtime-cli = { workspace = true, optional = true }
+substrate-build-script-utils = { workspace = true }
 
 [features]
 default = [

--- a/primitives/bloom-filter/Cargo.toml
+++ b/primitives/bloom-filter/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-frame-support = {default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42', version = '4.0.0-dev'}
-sp-std = { default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42', version = '5.0.0'}
-cp-cess-common = { default-features = false, path = '../common', version = '0.1.0' }
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+frame-support = {workspace = true}
+sp-std = { workspace = true}
+cp-cess-common = { default-features = false, path = '../common' }
 
 [features]
 default = ["std"]

--- a/primitives/common/Cargo.toml
+++ b/primitives/common/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+log = { workspace = true }
+codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, features = ["derive"] }
 
-frame-support = {default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '4.0.0-dev'}
-sp-std = { default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '5.0.0'}
-sp-core = { default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '7.0.0'}
+frame-support = { workspace = true }
+sp-std = { workspace = true }
+sp-core = { workspace = true }
 
 
 [features]

--- a/primitives/common/src/lib.rs
+++ b/primitives/common/src/lib.rs
@@ -1,15 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/* use */
-use frame_support::{
-	RuntimeDebug,
-	dispatch::{Decode, Encode},
-};
 use frame_support::{
 	BoundedVec,
+	RuntimeDebug,
 	pallet_prelude::ConstU32,
 };
-use codec::{MaxEncodedLen};
+use codec::{MaxEncodedLen, Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::prelude::Box;
 

--- a/primitives/enclave-verify/Cargo.toml
+++ b/primitives/enclave-verify/Cargo.toml
@@ -8,32 +8,32 @@ edition = "2021"
 # bls-signatures = { version = "0.14.0", default-features = false, features = ["pairing"]}
 
 # signature_bls = { version = "0.35.0" , default-features = false}
-ic-verify-bls-signature = { version = "0.2.0", path = '../../utils/verify-bls-signatures', default-features = false }
+ic-verify-bls-signature = { path = '../../utils/verify-bls-signatures', default-features = false }
 
-log = { version = "0.4.14", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42', version = '5.0'}
-cp-cess-common = { version = "0.1.0", path = '../common', default-features = false }
+log = { workspace = true }
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false }
+scale-info = { workspace = true, features = ["derive"] }
+sp-std = { workspace = true}
+cp-cess-common = { path = '../common', default-features = false }
 # ed25519-dalek = { version = "1.0.1", default-features = false, optional = true }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-rsa = { version = "0.8.2", default-features = false }
-hex = { version='0.4.3', default-features=false, features = ['alloc'] }
+serde_json = { workspace = true, features = ["alloc"] }
+rsa = { workspace = true }
+hex = { workspace = true, features = ['alloc'] }
 
-frame-support = {default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42', version = '4.0.0-dev'}
-sp-api = { version = "4.0.0-dev", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42' }
-sp-core = { version = "7.0.0", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42' }
-# sp-externalities = { version = "0.13.0", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42' }
-# sp-runtime-interface = { version = "7.0.0", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = 'cess-polkadot-v0.9.42' }
+frame-support = {workspace = true}
+sp-api = { workspace = true }
+sp-core = { workspace = true }
+# sp-externalities = { workspace = true }
+# sp-runtime-interface = { workspace = true }
 
 # verify sgx signture
 webpki = { package = "webpki", path = '../../utils/webpki', default-features = false }
-base64 = { default-features = false, features = ["alloc"], version = "0.12.2" }
+base64 = { workspace = true, features = ["alloc"] }
 # 
 
 [dev-dependencies]
-rand = "0.8.5"
-sp-io = { version = "7.0.0", default-features = false, branch = 'cess-polkadot-v0.9.42', git = 'https://github.com/CESSProject/substrate' }
+rand = { workspace = true }
+sp-io = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/scheduler-credit/Cargo.toml
+++ b/primitives/scheduler-credit/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-api = { version = "4.0.0-dev", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
-sp-std = { version = "5.0.0", default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42" }
-frame-support = {default-features = false, git = 'https://github.com/CESSProject/substrate', branch = "cess-polkadot-v0.9.42", version = '4.0.0-dev'}
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false }
+scale-info = { workspace = true, features = ["derive"] }
+sp-api = { workspace = true }
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+frame-support = { workspace = true }
 
 [features]
 default = ["std"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,99 +12,99 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 
 # third-party dependencies
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = [
+codec = { version = "3.2.2", package = "parity-scale-codec", default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
 # static_assertions
-log = { version = "0.4.17", default-features = false }
+log = { workspace = true }
 # hex-literal = { optional = true, version = "0.3.4" }
 
 # primitives
-sp-authority-discovery = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-cessp-consensus-rrsc = { version = "0.10.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-block-builder = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-inherents = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sp-authority-discovery = { workspace = true }
+cessp-consensus-rrsc = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-inherents = { workspace = true }
 # node-premitives
-sp-offchain = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-core = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-std = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-transaction-pool = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-version = { version = "5.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-sp-io = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+sp-offchain = { workspace = true }
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-api = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-session = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
+sp-io = { workspace = true }
 cp-enclave-verify = { path = '../primitives/enclave-verify', version = '0.1.0', default-features = false }
 cp-cess-common = { path = '../primitives/common', version = '0.1.0', default-features = false }
 
 # frame dependencies
-frame-executive = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", optional = true, branch = "cess-polkadot-v0.9.42" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", optional = true, branch = "cess-polkadot-v0.9.42" }
-frame-election-provider-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-frame-try-runtime = { version = "0.10.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", optional = true }
+frame-executive = { workspace = true }
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { workspace = true, optional = true }
+frame-election-provider-support = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { workspace = true, optional = true }
 # pallet-alliance
-pallet-assets = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-authority-discovery = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-authorship = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-rrsc = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bags-list = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-bounties = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-child-bounties = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-collective = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-contracts = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-contracts-primitives = { version = "7.0.0", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-assets = { workspace = true }
+pallet-authority-discovery = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-rrsc = { workspace = true }
+pallet-bags-list = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-bounties = { workspace = true }
+pallet-child-bounties = { workspace = true }
+pallet-collective = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
 # pallet-conviction-voting
 # pallet-democracy
-pallet-election-provider-multi-phase = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-election-provider-multi-phase = { workspace = true }
 # pallet-election-provider-support-benchmarking
 # pallet-elections-phragmen
 # pallet-fast-unstake
 # pallet-nis
-pallet-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-im-online = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-indices = {  version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-grandpa = { workspace = true }
+pallet-im-online = { workspace = true }
+pallet-indices = {  workspace = true }
 # pallet-identity
 # pallet-lottery
-pallet-membership = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-membership = { workspace = true }
 # pallet-message-queue
-pallet-mmr = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-multisig = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-mmr = { workspace = true }
+pallet-multisig = { workspace = true }
 # pallet-nomination-pools
 # pallet-nomination-pools-benchmarking
 # pallet-nomination-pools-runtime-api
-pallet-offences = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-offences = { workspace = true }
 # pallet-offences-benchmarking
-pallet-preimage = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-proxy = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-insecure-randomness-collective-flip = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-insecure-randomness-collective-flip = { workspace = true }
 # pallet-ranked-collective
 # pallet-recovery
 # pallet-referenda
 # pallet-remark
 # pallet-root-testing
-pallet-session = { version = "4.0.0-dev", features = [ "historical" ], default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-session = { workspace = true, features = [ "historical" ] }
 # pallet-session-benchmarking
-pallet-cess-staking = { default-features = false, path = "../c-pallets/staking", version = "4.0.0-dev" }
+pallet-cess-staking = { default-features = false, path = "../c-pallets/staking" }
 # pallet-staking-reward-curve
 # pallet-state-trie-migration
-pallet-scheduler = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-scheduler = { workspace = true }
 # pallet-society
-pallet-sudo = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-timestamp = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-sudo = { workspace = true }
+pallet-timestamp = { workspace = true }
 # pallet-tips
-pallet-treasury = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-treasury = { workspace = true }
 # pallet-utility
-pallet-transaction-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
-pallet-asset-tx-payment = { version = "4.0.0-dev", default-features = false, git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42" }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-asset-tx-payment = { workspace = true }
 
 cp-scheduler-credit = { default-features = false, path = "../primitives/scheduler-credit" }
 pallet-scheduler-credit = { default-features = false, path = "../c-pallets/scheduler-credit" }
@@ -117,29 +117,25 @@ pallet-file-bank = { default-features = false, path = "../c-pallets/file-bank" }
 pallet-tee-worker = { default-features = false, path = "../c-pallets/tee-worker" }
 pallet-storage-handler = { default-features = false, path = "../c-pallets/storage-handler" }
 pallet-oss = { default-features = false, path = "../c-pallets/oss" }
+pallet-cacher = { default-features = false, path = "../c-pallets/cacher" }
 
 # Frontier
-fp-account = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-evm = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-rpc = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-fp-self-contained = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+fp-account = { workspace = true }
+fp-evm = { workspace = true }
+fp-rpc = { workspace = true }
+fp-self-contained = { workspace = true }
 # Frontier
-pallet-base-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-ethereum = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-evm = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/CESSProject/frontier", branch = "cess-polkadot-v0.9.42", default-features = false }
+pallet-base-fee = { workspace = true }
+pallet-dynamic-fee = { workspace = true }
+pallet-ethereum = { workspace = true }
+pallet-evm = { workspace = true }
+pallet-evm-chain-id = { workspace = true }
+pallet-evm-precompile-modexp = { workspace = true }
+pallet-evm-precompile-sha3fips = { workspace = true }
+pallet-evm-precompile-simple = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/CESSProject/substrate", branch = "cess-polkadot-v0.9.42", version = "5.0.0-dev", optional = true }
-
-[dependencies.pallet-cacher]
-default-features = false
-path = '../c-pallets/cacher'
-version = '0.7.0'
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/utils/verify-bls-signatures/Cargo.toml
+++ b/utils/verify-bls-signatures/Cargo.toml
@@ -6,9 +6,9 @@ license = "Apache-2.0"
 description = "A library for handling BLS signatures"
 
 [dependencies]
-bls12_381 = { version = "0.7", default-features = false, features = ["groups", "pairings", "alloc", "experimental"] }
-pairing = { version = "0.22", default-features = false }
-lazy_static = { version = "1", default-features = false }
+bls12_381 = { workspace = true, features = ["groups", "pairings", "alloc", "experimental"] }
+pairing = { workspace = true }
+lazy_static = { workspace = true }
 
 # Check references:
 #  - https://docs.rs/getrandom/latest/getrandom/index.html
@@ -16,9 +16,9 @@ lazy_static = { version = "1", default-features = false }
 #  - https://github.com/rust-random/getrandom/pull/109 // This one explains why "custom" feature
 #    is added, and we will need to call `register_custom_getrandom` in future.
 #  - https://docs.rs/getrandom/latest/getrandom/index.html#custom-implementations
-getrandom = { version = "0.2.10", default-features = false, features = ["custom"] }
-sha2 = { version = "0.9", default-features = false }
-hex = { version = "0.4", default-features = false }
+getrandom = { workspace = true, features = ["custom"] }
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
-rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
+rand = { workspace = true, features = ["getrandom"] }


### PR DESCRIPTION
* All dependencies of member packages are changed to use inherited from workspace, except;
* the `parity-scale-codec` crate don't change yet, because the dependency renaming seens have a bug in workspace dependency inheriting (that bug will be reproducible, I'll submit a issue to cargo repository);
* and the both package `ring` and `webpki` under path `utils` nothing to change;
* the only package that can affect dependency changes is `pallet-file-bank`, removed dependency `parking_lot`, I think it should not be used on `Pallet`, and after removal, there is no problem with compilation.