### PR TITLE
fix: territory calculate price different

### DIFF
--- a/pallets/storage-handler/src/lib.rs
+++ b/pallets/storage-handler/src/lib.rs
@@ -967,6 +967,18 @@ pub mod pallet {
 
             Ok(())
         }
+
+        // FOR TEST
+		#[pallet::call_index(9)]
+		#[transactional]
+		#[pallet::weight(Weight::zero())]
+		pub fn define_update_price(origin: OriginFor<T>, price: u128) -> DispatchResult {
+			let _ = ensure_root(origin)?;
+			let default_price: BalanceOf<T> = price.try_into().map_err(|_| Error::<T>::Overflow)?;
+			UnitPrice::<T>::put(default_price);
+
+			Ok(())
+		}
     }
 }
 

--- a/standalone/chain/runtime/src/lib.rs
+++ b/standalone/chain/runtime/src/lib.rs
@@ -146,7 +146,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 120,
+	spec_version: 121,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/standalone/chain/runtime/src/lib.rs
+++ b/standalone/chain/runtime/src/lib.rs
@@ -146,7 +146,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 119,
+	spec_version: 120,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Fix #398 

- Unified the price calculation rules when minting territories.

Upgrade CESS Chain online `spec_version` from 119 -> 120.