### PR TITLE
fix: compile error with `runtime-benchmarks` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "substrate-build-script-utils",
 ]
 
 [[package]]
@@ -5840,20 +5841,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generate-bags"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
-dependencies = [
- "chrono",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "num-format",
- "pallet-staking",
- "sp-staking",
-]
 
 [[package]]
 name = "generic-array"
@@ -13021,7 +13008,6 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "generate-bags",
  "mmr-rpc",
  "pallet-alliance",
  "pallet-asset-conversion",

--- a/standalone/chain/node/Cargo.toml
+++ b/standalone/chain/node/Cargo.toml
@@ -31,7 +31,6 @@ polkadot-sdk = { workspace = true, default-features = true, features = [
 	"frame-benchmarking-cli",
 	"frame-remote-externalities",
 	"frame-support-procedural-tools",
-	"generate-bags",
 	"mmr-rpc",
 	"pallet-transaction-payment-rpc",
 	"sc-allocator",
@@ -120,7 +119,7 @@ fp-evm = { workspace = true, features = ["default"] }
 fp-rpc = { workspace = true, features = ["default"] }
 
 [build-dependencies]
-polkadot-sdk = { workspace = true, features = ["substrate-build-script-utils"] }
+substrate-build-script-utils = { workspace = true, default-features = true }
 
 [features]
 default = ["rocksdb", "sql", "txpool"]

--- a/standalone/chain/node/build.rs
+++ b/standalone/chain/node/build.rs
@@ -1,4 +1,4 @@
-use polkadot_sdk::substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
 	generate_cargo_keys();

--- a/standalone/chain/node/src/command.rs
+++ b/standalone/chain/node/src/command.rs
@@ -194,7 +194,7 @@ pub fn run() -> sc_cli::Result<()> {
 					),
 					#[cfg(feature = "runtime-benchmarks")]
 					BenchmarkCmd::Storage(cmd) => {
-						let PartialComponents { client, backend, .. } =
+						let sc_service::PartialComponents { client, backend, .. } =
 							service::new_partial(&config)?;
 						let db = backend.expose_db();
 						let storage = backend.expose_storage();

--- a/standalone/chain/runtime/Cargo.toml
+++ b/standalone/chain/runtime/Cargo.toml
@@ -173,7 +173,11 @@ std = [
 	"pallet-tee-worker/std",
 ]
 runtime-benchmarks = [
+	"polkadot-sdk/frame-benchmarking",
+	"polkadot-sdk/frame-system-benchmarking",
+	"polkadot-sdk/pallet-election-provider-support-benchmarking",
 	"polkadot-sdk/runtime-benchmarks",
+	"polkadot-sdk/sp-storage",
 	# Frontier
 	"pallet-ethereum/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",

--- a/standalone/chain/runtime/src/lib.rs
+++ b/standalone/chain/runtime/src/lib.rs
@@ -1798,6 +1798,8 @@ impl pallet_reservoir::Config for Runtime {
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
+	use polkadot_sdk::*;
+
 	frame_benchmarking::define_benchmarks!(
 		[frame_benchmarking, BaselineBench::<Runtime>]
 		[pallet_assets, Assets]
@@ -2254,7 +2256,7 @@ impl_runtime_apis! {
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
 			use frame_benchmarking::{baseline, Benchmarking, BenchmarkBatch};
-			use sp_storage::TrackedStorageKey;
+			use polkadot_sdk::sp_storage::TrackedStorageKey;
 
 			use pallet_election_provider_support_benchmarking::Pallet as EPSBench;
 			use frame_system_benchmarking::Pallet as SystemBench;


### PR DESCRIPTION
This feature was missed after upgrading the `polkadot-sdk`