### PR TITLE
hotfix: point the `polkadot-sdk` to the forked repository to fix memory leak about `litep2p` on `stable2409` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-primitives"
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "arrayvec 0.7.6",
  "bytes",
@@ -172,7 +172,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "approx"
@@ -294,7 +294,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -668,7 +668,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -730,7 +730,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -747,14 +747,15 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-test-utils"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "20.0.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
+ "pallet-asset-conversion",
  "pallet-assets",
  "pallet-balances",
  "pallet-collator-selection",
@@ -766,18 +767,19 @@ dependencies = [
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "assets-common"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -790,7 +792,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -828,7 +830,7 @@ checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "futures-lite 2.5.0",
  "slab",
 ]
@@ -878,7 +880,7 @@ dependencies = [
  "futures-lite 2.5.0",
  "parking",
  "polling 3.7.4",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -928,7 +930,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "windows-sys 0.48.0",
 ]
 
@@ -944,7 +946,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -964,7 +966,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1026,7 +1028,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1048,7 +1050,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -1090,7 +1092,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.5",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -1148,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
@@ -1162,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hash-db",
  "log",
@@ -1195,7 +1197,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1330,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1429,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1439,14 +1441,14 @@ dependencies = [
  "serde",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "bp-messages"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1462,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1472,14 +1474,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "bp-polkadot"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1492,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1503,14 +1505,14 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "bp-relayers"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1521,14 +1523,14 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "bp-runtime"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1541,7 +1543,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std 14.0.0",
  "sp-trie 37.0.0",
@@ -1551,7 +1553,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1563,15 +1565,15 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.4.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1588,19 +1590,19 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-common"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1609,15 +1611,15 @@ dependencies = [
  "scale-info",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.20.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1650,7 +1652,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-xcm",
  "staging-xcm-builder",
@@ -1659,8 +1661,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1681,7 +1683,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-trie 37.0.0",
  "staging-xcm",
@@ -1732,9 +1734,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1744,9 +1746,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bzip2-sys"
@@ -1780,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -1795,7 +1797,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.24",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1803,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "jobserver",
  "libc",
@@ -1870,7 +1872,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
 ]
@@ -1901,7 +1903,7 @@ dependencies = [
  "sgx-attestation",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
@@ -1954,10 +1956,10 @@ dependencies = [
 name = "ces-sanitized-logger"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.11.5",
+ "env_logger 0.11.6",
  "log",
  "tracing-core",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -1989,7 +1991,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
  "trie-db 0.29.1",
@@ -2016,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "cess-node"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -2059,7 +2061,7 @@ name = "cess-node-primitives"
 version = "2.0.0"
 dependencies = [
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -2145,7 +2147,7 @@ dependencies = [
  "sp-inherents",
  "sp-keyring",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
  "sp-tracing 17.0.1",
  "substrate-prometheus-endpoint",
@@ -2176,7 +2178,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keyring",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-test-runtime-client",
  "thiserror 1.0.69",
  "tokio",
@@ -2196,7 +2198,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -2213,7 +2215,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-timestamp",
 ]
@@ -2245,7 +2247,7 @@ dependencies = [
  "finality-grandpa",
  "frame-system",
  "glob",
- "h2 0.4.6",
+ "h2 0.4.7",
  "hash-db",
  "hex",
  "hex-literal",
@@ -2284,7 +2286,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
  "thiserror 1.0.69",
@@ -2322,7 +2324,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tonic",
  "tonic-build",
 ]
@@ -2432,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2530,7 +2532,7 @@ dependencies = [
  "serde_json",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
  "tokio",
  "tonic",
@@ -2569,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2579,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2599,14 +2601,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmac"
@@ -2621,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "coarsetime"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
+checksum = "4252bf230cb600c19826a575b31c8c9c84c6f11acfab6dfcad2e941b10b6f8e2"
 dependencies = [
  "libc",
  "wasix",
@@ -2658,7 +2660,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2705,22 +2707,22 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "const-hex"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2861,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -2992,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -3011,18 +3013,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -3095,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -3105,14 +3107,14 @@ dependencies = [
  "sc-service",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "url",
 ]
 
 [[package]]
 name = "cumulus-client-collator"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -3128,14 +3130,14 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3169,7 +3171,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-timestamp",
  "substrate-prometheus-endpoint",
@@ -3180,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3199,7 +3201,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
  "sp-trie 37.0.0",
  "sp-version",
@@ -3210,14 +3212,14 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
 ]
@@ -3225,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3240,7 +3242,7 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -3248,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3265,7 +3267,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-version",
  "tracing",
@@ -3274,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3286,7 +3288,7 @@ dependencies = [
  "sp-api",
  "sp-crypto-hashing",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-trie 37.0.0",
@@ -3296,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3314,7 +3316,7 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version",
  "tracing",
 ]
@@ -3322,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -3352,14 +3354,14 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3370,13 +3372,13 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3386,14 +3388,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3416,7 +3418,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std 14.0.0",
  "sp-trie 37.0.0",
@@ -3429,31 +3431,31 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3462,13 +3464,13 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3476,14 +3478,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections 0.2.2",
  "bp-xcm-bridge-hub-router",
@@ -3499,7 +3501,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3508,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3516,14 +3518,14 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3532,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3540,7 +3542,7 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
  "staging-xcm",
 ]
@@ -3548,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3562,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-externalities 0.29.0",
  "sp-runtime-interface 28.0.0",
@@ -3572,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3582,13 +3584,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3598,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3606,7 +3608,7 @@ dependencies = [
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3615,7 +3617,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3632,14 +3634,14 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3658,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -3684,7 +3686,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-babe",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tokio",
  "tracing",
@@ -3693,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3718,7 +3720,7 @@ dependencies = [
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-version",
@@ -3732,12 +3734,12 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
 ]
@@ -3792,7 +3794,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3810,46 +3812,61 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c042a0ba58aaff55299632834d1ea53ceff73d62373f62c9ae60890ad1b942"
+checksum = "4d44ff199ff93242c3afe480ab588d544dd08d72e92885e152ffebc670f076ad"
 dependencies = [
  "cc",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dc1c88d0fdac57518a9b1f6c4f4fb2aca8f3c30c0d03d7d8518b47ca0bcea6"
+checksum = "66fd8f17ad454fc1e4f4ab83abffcc88a532e90350d3ffddcb73030220fcbd52"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.87",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4717c9c806a9e07fdcb34c84965a414ea40fafe57667187052cf1eb7f5e8a8a9"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7ed7d30b289e2592cc55bc2ccd89803a63c913e008e6eb59f06cddf45bb52f"
+checksum = "2f6515329bf3d98f4073101c7866ff2bec4e635a13acb82e3f3753fff0bf43cb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c465d22de46b851c04630a5fc749a26005b263632ed2e0d9cc81518ead78d"
+checksum = "fb93e6a7ce8ec985c02bbb758237a31598b340acbbc3c19c5a4fa6adaaac92ab"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3897,7 +3914,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3919,7 +3936,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4029,7 +4046,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4060,7 +4077,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4073,7 +4090,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4093,7 +4110,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "unicode-xid",
 ]
 
@@ -4189,7 +4206,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4219,7 +4236,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.91",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
@@ -4403,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
@@ -4428,7 +4445,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4448,7 +4465,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4459,14 +4476,14 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -4487,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4512,12 +4529,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4623,9 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.3.1",
  "pin-project-lite",
@@ -4710,7 +4727,7 @@ dependencies = [
  "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4742,15 +4759,26 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.6",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
  "arrayvec 0.7.6",
  "auto_impl",
@@ -4774,29 +4802,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "async-trait",
  "fp-storage",
  "parity-scale-codec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "clap",
  "ethereum-types",
@@ -4808,13 +4836,13 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4823,14 +4851,14 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4852,7 +4880,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sqlx",
  "tokio",
 ]
@@ -4860,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4876,14 +4904,14 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tokio",
 ]
 
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4925,7 +4953,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-timestamp",
@@ -4937,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4952,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4962,7 +4990,7 @@ dependencies = [
  "sc-client-api",
  "sp-api",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-storage 21.0.0",
 ]
 
@@ -5092,9 +5120,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -5114,7 +5142,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5141,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "hex",
  "impl-serde",
@@ -5152,7 +5180,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "staging-xcm",
 ]
@@ -5160,18 +5188,18 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "async-trait",
  "sp-core 34.0.0",
@@ -5181,7 +5209,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -5193,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "evm",
  "frame-support",
@@ -5202,13 +5230,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -5217,26 +5245,26 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5251,7 +5279,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5266,7 +5294,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-storage 21.0.0",
  "static_assertions",
@@ -5275,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5313,7 +5341,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
  "sp-trie 37.0.0",
@@ -5325,7 +5353,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5333,24 +5361,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5360,13 +5388,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5377,7 +5405,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
@@ -5405,20 +5433,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -5427,13 +5444,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-remote-externalities"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "indicatif",
@@ -5444,7 +5461,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "spinners",
  "substrate-rpc-client",
@@ -5454,8 +5471,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5483,7 +5500,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-state-machine 0.43.0",
  "sp-std 14.0.0",
@@ -5496,7 +5513,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5510,35 +5527,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-support-test"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -5556,7 +5573,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-version",
  "static_assertions",
@@ -5566,20 +5583,20 @@ dependencies = [
 [[package]]
 name = "frame-support-test-pallet"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5590,7 +5607,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-version",
  "sp-weights 31.0.0",
@@ -5599,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5607,13 +5624,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5623,12 +5640,12 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -5656,7 +5673,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "windows-sys 0.48.0",
 ]
 
@@ -5763,7 +5780,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -5778,7 +5795,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5992,7 +6009,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6001,17 +6018,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.6.0",
+ "http 1.2.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -6103,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -6174,9 +6191,9 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -6185,7 +6202,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.4.0",
+ "idna 1.0.3",
  "ipnet",
  "once_cell",
  "rand 0.8.5",
@@ -6198,9 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6268,11 +6285,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6299,9 +6316,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -6326,7 +6343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -6337,7 +6354,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -6362,9 +6379,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -6377,7 +6394,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -6386,15 +6403,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.7",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -6413,7 +6430,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -6423,21 +6440,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.0",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
- "rustls 0.23.17",
- "rustls-pki-types 1.10.0",
+ "rustls 0.23.20",
+ "rustls-pki-types 1.10.1",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -6446,7 +6463,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -6461,11 +6478,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -6609,7 +6626,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6672,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
+checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io 2.4.0",
  "core-foundation",
@@ -6683,6 +6700,10 @@ dependencies = [
  "if-addrs",
  "ipnet",
  "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
  "rtnetlink",
  "system-configuration",
  "tokio",
@@ -6700,7 +6721,7 @@ dependencies = [
  "bytes",
  "futures",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rand 0.8.5",
  "tokio",
@@ -6763,13 +6784,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6804,12 +6825,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -6905,7 +6926,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -6981,9 +7002,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -7016,10 +7037,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -7079,16 +7101,16 @@ checksum = "548125b159ba1314104f5bb5f38519e03a41862786aa3925cf349aae9cdd546e"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "jsonrpsee-core 0.24.7",
  "pin-project",
- "rustls 0.23.17",
- "rustls-pki-types 1.10.0",
+ "rustls 0.23.20",
+ "rustls-pki-types 1.10.1",
  "rustls-platform-verifier",
- "soketto 0.8.0",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tracing",
  "url",
@@ -7106,7 +7128,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "jsonrpsee-types 0.20.4",
  "rustc-hash 1.1.0",
  "serde",
@@ -7126,14 +7148,14 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.24.7",
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7149,7 +7171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c7b9f95208927653e7965a98525e7fc641781cab89f0e27c43fa2974405683"
 dependencies = [
  "async-trait",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "jsonrpsee-core 0.20.4",
  "jsonrpsee-types 0.20.4",
@@ -7171,12 +7193,12 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
- "rustls 0.23.17",
+ "rustls 0.23.20",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -7197,7 +7219,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7207,10 +7229,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
@@ -7218,7 +7240,7 @@ dependencies = [
  "route-recognizer",
  "serde",
  "serde_json",
- "soketto 0.8.0",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -7247,7 +7269,7 @@ version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
 dependencies = [
- "http 1.1.0",
+ "http 1.2.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -7259,7 +7281,7 @@ version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe322e0896d0955a3ebdd5bf813571c53fea29edd713bc315b76620b327e86d"
 dependencies = [
- "http 1.1.0",
+ "http 1.2.0",
  "jsonrpsee-client-transport 0.24.7",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
@@ -7367,15 +7389,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -7462,7 +7484,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.3",
@@ -7517,14 +7539,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
+checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek 2.1.1",
  "hkdf",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
@@ -7577,7 +7599,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "trust-dns-proto 0.22.0",
  "void",
@@ -7613,7 +7635,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
@@ -7662,7 +7684,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "rustls 0.21.12",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -7718,7 +7740,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7734,7 +7756,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "log",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
 ]
 
@@ -7802,7 +7824,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "rw-stream-sink",
- "soketto 0.8.0",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "url",
  "webpki-roots 0.25.4",
@@ -7829,7 +7851,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
 ]
 
 [[package]]
@@ -7934,9 +7956,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_hash_set"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+checksum = "bae85b5be22d9843c80e5fc80e9b64c8a3b1f98f867c709956eca3efff4e92e2"
 dependencies = [
  "linked-hash-map",
 ]
@@ -7982,27 +8004,28 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litep2p"
-version = "0.6.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f46c51c205264b834ceed95c8b195026e700494bc3991aaba3b4ea9e20626d9"
+checksum = "2b0fef34af8847e816003bf7fdeac5ea50b9a7a88441ac927a6166b5e812ab79"
 dependencies = [
  "async-trait",
- "bs58 0.4.0",
+ "bs58 0.5.1",
  "bytes",
  "cid 0.10.1",
  "ed25519-dalek 2.1.1",
  "futures",
  "futures-timer",
  "hex-literal",
- "indexmap 2.6.0",
+ "hickory-resolver",
+ "indexmap 2.7.0",
  "libc",
- "mockall 0.12.1",
+ "mockall 0.13.1",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
@@ -8010,8 +8033,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "prost 0.12.6",
- "prost-build 0.11.9",
- "quinn 0.9.4",
+ "prost-build 0.13.4",
  "rand 0.8.5",
  "rcgen",
  "ring 0.16.20",
@@ -8021,20 +8043,17 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "static_assertions",
- "str0m",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
- "trust-dns-resolver",
  "uint",
  "unsigned-varint 0.8.0",
  "url",
- "webpki",
  "x25519-dalek",
  "x509-parser 0.16.0",
  "yasna",
@@ -8084,7 +8103,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -8133,7 +8152,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8147,7 +8166,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8158,7 +8177,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8169,7 +8188,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8236,7 +8255,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.40",
+ "rustix 0.38.42",
 ]
 
 [[package]]
@@ -8292,13 +8311,13 @@ checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f6d92804ed0100803d51fa9b21fd9432b5d122ba4c713dc26fe6d2f619cf6"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
 dependencies = [
  "array-bytes 6.2.3",
  "blake3",
- "frame-metadata 18.0.0",
+ "frame-metadata 16.0.0",
  "parity-scale-codec",
  "scale-decode 0.13.1",
  "scale-info",
@@ -8353,20 +8372,19 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -8400,7 +8418,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "log",
@@ -8413,13 +8431,13 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "mmr-rpc"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -8428,7 +8446,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8448,16 +8466,15 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
- "mockall_derive 0.12.1",
- "predicates 3.1.2",
+ "mockall_derive 0.13.1",
+ "predicates 3.1.3",
  "predicates-tree",
 ]
 
@@ -8475,14 +8492,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8521,7 +8538,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -8576,9 +8593,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "unsigned-varint 0.8.0",
@@ -8641,7 +8658,7 @@ checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8693,21 +8710,20 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.4.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
  "byteorder",
- "libc",
  "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.12.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -8731,9 +8747,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 dependencies = [
  "bytes",
  "futures",
@@ -8746,9 +8762,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
  "futures",
@@ -8771,9 +8787,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -8913,24 +8929,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -9012,7 +9017,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -9044,9 +9049,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -9110,7 +9115,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -9120,15 +9125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.1+3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9136,7 +9132,6 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -9171,7 +9166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.11.0",
  "petgraph",
  "proc-macro-crate 3.2.0",
@@ -9198,7 +9193,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -9212,13 +9207,13 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9230,13 +9225,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9248,13 +9243,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9262,13 +9257,13 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9276,13 +9271,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9293,13 +9288,13 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9309,13 +9304,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9324,13 +9319,13 @@ dependencies = [
  "pallet-assets",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-atomic-swap"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9338,7 +9333,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9375,7 +9370,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
 ]
@@ -9383,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9393,13 +9388,13 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9408,26 +9403,26 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-authority-discovery",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9442,7 +9437,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
 ]
@@ -9450,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9464,14 +9459,14 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9480,13 +9475,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9494,13 +9489,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9511,7 +9506,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
 ]
@@ -9519,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9537,14 +9532,14 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9555,13 +9550,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9573,14 +9568,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9591,7 +9586,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-trie 37.0.0",
 ]
@@ -9599,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9612,14 +9607,14 @@ dependencies = [
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9636,14 +9631,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.17.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9655,7 +9650,7 @@ dependencies = [
  "sp-api",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9672,7 +9667,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
@@ -9699,7 +9694,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
  "sp-tracing 17.0.1",
@@ -9716,7 +9711,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
 ]
@@ -9724,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9736,13 +9731,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9754,14 +9749,14 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9771,13 +9766,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-collective-content"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9785,13 +9780,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-contracts"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -9813,7 +9808,7 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9824,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9848,7 +9843,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9859,17 +9854,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9881,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9891,13 +9886,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "22.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9909,13 +9904,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9923,14 +9918,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9941,13 +9936,13 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-dev-mode"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9956,13 +9951,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -9977,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9992,27 +9987,27 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10023,14 +10018,14 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -10046,14 +10041,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version",
 ]
 
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "environmental",
  "evm",
@@ -10070,7 +10065,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -10089,14 +10084,14 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10107,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "num",
@@ -10116,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -10125,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -10135,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10146,7 +10141,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
@@ -10187,7 +10182,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
 ]
@@ -10195,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10207,13 +10202,13 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10227,7 +10222,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
 ]
@@ -10235,7 +10230,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10245,13 +10240,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10263,14 +10258,14 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10280,39 +10275,39 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-lottery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10322,13 +10317,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10340,14 +10335,14 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-migrations"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10358,13 +10353,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10377,13 +10372,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
  "sp-mixnet",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10394,13 +10389,13 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10409,13 +10404,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10425,13 +10420,13 @@ dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10442,13 +10437,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -10458,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10467,13 +10462,13 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-node-authorization"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10482,13 +10477,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "35.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10498,7 +10493,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-tracing 17.0.1",
 ]
@@ -10506,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10518,15 +10513,15 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "33.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10536,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10545,14 +10540,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10568,7 +10563,7 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
@@ -10588,14 +10583,14 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-paged-list"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10606,13 +10601,13 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10623,13 +10618,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10639,13 +10634,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10653,13 +10648,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10671,13 +10666,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10685,13 +10680,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10703,13 +10698,13 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-remark"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10719,7 +10714,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -10731,14 +10726,14 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-revive"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -10759,7 +10754,7 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -10768,13 +10763,13 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "frame-system",
  "parity-wasm",
  "polkavm-linker 0.10.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "tempfile",
  "toml 0.8.19",
 ]
@@ -10782,7 +10777,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-mock-network"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10805,7 +10800,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-xcm",
  "staging-xcm-builder",
@@ -10816,17 +10811,17 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10838,7 +10833,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10846,14 +10841,14 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10861,7 +10856,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -10887,7 +10882,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "sp-std 14.0.0",
@@ -10896,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10908,13 +10903,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-salary"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "23.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10926,13 +10921,13 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10942,7 +10937,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -10960,27 +10955,27 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-scored-pool"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10991,7 +10986,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "sp-state-machine 0.43.0",
@@ -11001,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11010,20 +11005,20 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
 ]
 
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -11053,7 +11048,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
 ]
@@ -11061,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11072,13 +11067,13 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11093,25 +11088,25 @@ dependencies = [
  "serde",
  "sp-application-crypto 38.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "sp-arithmetic 26.0.0",
@@ -11120,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11130,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11140,13 +11135,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-statement"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11156,7 +11151,7 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-statement-store",
 ]
 
@@ -11175,14 +11170,14 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11191,7 +11186,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -11224,7 +11219,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
  "sp-std 14.0.0",
 ]
@@ -11232,7 +11227,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11243,7 +11238,7 @@ dependencies = [
  "scale-info",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-storage 21.0.0",
  "sp-timestamp",
 ]
@@ -11251,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11263,13 +11258,13 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11278,13 +11273,13 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11293,26 +11288,26 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "pallet-transaction-storage"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11325,14 +11320,14 @@ dependencies = [
  "serde",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-transaction-storage-proof",
 ]
 
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11344,13 +11339,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-tx-pause"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11361,13 +11356,13 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11375,13 +11370,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11390,13 +11385,13 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11404,13 +11399,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11418,13 +11413,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections 0.2.2",
  "frame-benchmarking",
@@ -11437,7 +11432,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11448,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11457,7 +11452,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11465,8 +11460,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.13.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11478,7 +11473,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -11487,8 +11482,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.15.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11498,7 +11493,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -11507,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11527,7 +11522,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -11536,8 +11531,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "19.0.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -11551,17 +11546,19 @@ dependencies = [
  "pallet-session",
  "pallet-timestamp",
  "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-consensus-aura",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -11715,7 +11712,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -11813,20 +11810,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -11834,22 +11831,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
@@ -11863,7 +11860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -11883,7 +11880,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -11915,7 +11912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "futures-io",
 ]
 
@@ -11959,8 +11956,8 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "18.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "futures",
@@ -11980,7 +11977,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "always-assert",
  "futures",
@@ -11996,7 +11993,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
@@ -12020,7 +12017,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12053,7 +12050,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cfg-if",
  "clap",
@@ -12073,7 +12070,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
 ]
@@ -12081,7 +12078,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12095,7 +12092,7 @@ dependencies = [
  "schnellru",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "tokio-util",
  "tracing-gum",
@@ -12104,24 +12101,24 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "derive_more 0.99.18",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -12140,7 +12137,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12154,7 +12151,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12176,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12199,7 +12196,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12216,8 +12213,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "18.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "derive_more 0.99.18",
@@ -12242,7 +12239,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
@@ -12250,7 +12247,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "futures",
@@ -12272,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12292,7 +12289,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12307,7 +12304,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12329,7 +12326,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12343,7 +12340,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12360,7 +12357,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "fatality",
  "futures",
@@ -12379,7 +12376,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12396,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "fatality",
  "futures",
@@ -12410,7 +12407,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12428,7 +12425,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12457,7 +12454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -12473,7 +12470,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12499,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12514,7 +12511,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "lazy_static",
  "log",
@@ -12533,7 +12530,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bs58 0.5.1",
  "futures",
@@ -12551,8 +12548,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "18.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "18.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12569,7 +12566,7 @@ dependencies = [
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
  "thiserror 1.0.69",
  "tracing-gum",
@@ -12578,7 +12575,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12596,7 +12593,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
  "sp-maybe-compressed-blob",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
  "zstd 0.12.4",
 ]
@@ -12604,7 +12601,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -12614,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12636,7 +12633,7 @@ dependencies = [
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -12644,7 +12641,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -12680,7 +12677,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12702,7 +12699,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-lib"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "clap",
@@ -12757,7 +12754,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
@@ -12771,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections 0.2.2",
  "derive_more 0.99.18",
@@ -12780,14 +12777,14 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -12806,14 +12803,14 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "polkadot-rpc"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "mmr-rpc",
@@ -12840,7 +12837,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-frame-rpc-system",
  "substrate-state-trie-migration-rpc",
 ]
@@ -12848,7 +12845,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12886,7 +12883,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "staging-xcm",
@@ -12898,7 +12895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -12910,7 +12907,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12947,7 +12944,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "sp-std 14.0.0",
@@ -12958,8 +12955,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.9.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -13213,7 +13210,7 @@ dependencies = [
  "sp-offchain",
  "sp-panic-handler 13.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-session",
  "sp-staking",
@@ -13250,7 +13247,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13272,7 +13269,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-storage 21.0.0",
  "sp-transaction-pool",
@@ -13282,7 +13279,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13372,7 +13369,7 @@ dependencies = [
  "sp-keyring",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-timestamp",
  "sp-transaction-pool",
@@ -13389,14 +13386,14 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -13412,7 +13409,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13510,7 +13507,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13522,7 +13519,7 @@ dependencies = [
  "polkavm-common 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13532,7 +13529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13542,7 +13539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9324fe036de37c17829af233b46ef6b5562d4a0c09bb7fdb9f8378856dee30cf"
 dependencies = [
  "polkavm-derive-impl 0.10.0",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13569,7 +13566,7 @@ dependencies = [
  "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "object 0.36.5",
+ "object 0.36.7",
  "polkavm-common 0.10.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
@@ -13613,7 +13610,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -13643,9 +13640,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "powerfmt"
@@ -13678,9 +13675,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -13688,15 +13685,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -13729,7 +13726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13814,7 +13811,7 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13825,14 +13822,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -13871,7 +13868,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13915,6 +13912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13953,7 +13960,27 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.91",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap 0.10.0",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.25",
+ "prost 0.13.4",
+ "prost-types 0.13.4",
+ "regex",
+ "syn 2.0.91",
  "tempfile",
 ]
 
@@ -13980,7 +14007,20 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -13999,6 +14039,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost 0.13.4",
 ]
 
 [[package]]
@@ -14047,14 +14096,14 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -14095,24 +14144,6 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.9.6",
- "quinn-udp 0.3.2",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "webpki",
-]
-
-[[package]]
-name = "quinn"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
@@ -14138,31 +14169,13 @@ dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto 0.11.9",
- "quinn-udp 0.5.7",
- "rustc-hash 2.0.0",
- "rustls 0.23.17",
- "socket2 0.5.7",
- "thiserror 2.0.3",
+ "quinn-udp 0.5.9",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.20",
+ "socket2 0.5.8",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "slab",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -14192,27 +14205,14 @@ dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 2.0.0",
- "rustls 0.23.17",
- "rustls-pki-types 1.10.0",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.20",
+ "rustls-pki-types 1.10.1",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
-dependencies = [
- "libc",
- "quinn-proto 0.9.6",
- "socket2 0.4.10",
- "tracing",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -14223,21 +14223,21 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -14455,7 +14455,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem 1.1.1",
  "ring 0.16.20",
- "time 0.3.36",
+ "time 0.3.37",
  "yasna",
 ]
 
@@ -14479,9 +14479,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -14526,7 +14526,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -14616,11 +14616,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hickory-resolver",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -14630,22 +14630,22 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn 0.11.6",
- "rustls 0.23.17",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -14731,18 +14731,18 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
+checksum = "b11a153aec4a6ab60795f8ebe2923c597b16b05bb1504377451e705ef1a45323"
 dependencies = [
  "bytes",
- "hashbrown 0.14.5",
- "indexmap 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
  "rend",
- "rkyv_derive 0.8.8",
+ "rkyv_derive 0.8.9",
  "tinyvec",
  "uuid",
 ]
@@ -14760,13 +14760,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
+checksum = "beb382a4d9f53bd5c0be86b10d8179c3f8a14c30bf774ff77096ed6581e35981"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -14826,7 +14826,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14909,7 +14909,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-mmr-primitives",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "sp-storage 21.0.0",
@@ -14926,14 +14926,14 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -14990,15 +14990,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.10.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-packet-utils",
  "netlink-proto",
- "nix 0.24.3",
+ "netlink-sys",
+ "nix 0.26.4",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -15015,16 +15018,18 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -15070,9 +15075,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc-hex"
@@ -15110,7 +15115,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.24",
 ]
 
 [[package]]
@@ -15152,15 +15157,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15188,14 +15193,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "rustls-webpki 0.102.8",
  "subtle 2.6.1",
  "zeroize",
@@ -15221,7 +15226,7 @@ checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.2.0",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "schannel",
  "security-framework",
 ]
@@ -15241,7 +15246,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
 ]
 
 [[package]]
@@ -15252,9 +15257,9 @@ checksum = "a47003264dea418db67060fa420ad16d0d2f8f0a0360d825c00e177ac52cb5d8"
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -15270,13 +15275,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.17",
+ "rustls 0.23.20",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
  "winapi",
 ]
 
@@ -15313,7 +15318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "untrusted 0.9.0",
 ]
 
@@ -15374,9 +15379,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -15393,7 +15398,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "sp-core 34.0.0",
@@ -15404,7 +15409,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -15413,7 +15418,7 @@ dependencies = [
  "libp2p",
  "linked_hash_set",
  "log",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build 0.12.6",
@@ -15426,7 +15431,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15434,7 +15439,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -15449,14 +15454,14 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15464,14 +15469,14 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -15491,7 +15496,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-genesis-builder",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-tracing 17.0.1",
 ]
@@ -15499,18 +15504,18 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -15542,7 +15547,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore 0.40.0",
  "sp-panic-handler 13.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version",
  "thiserror 1.0.69",
  "tokio",
@@ -15551,7 +15556,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "fnv",
  "futures",
@@ -15567,7 +15572,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-database",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-statement-store",
  "sp-storage 21.0.0",
@@ -15578,7 +15583,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15596,7 +15601,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
 ]
@@ -15604,7 +15609,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -15619,7 +15624,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -15628,7 +15633,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -15649,7 +15654,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15657,7 +15662,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15685,7 +15690,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-inherents",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15693,7 +15698,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.7",
@@ -15708,14 +15713,14 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-beefy"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15741,7 +15746,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -15751,7 +15756,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.7",
@@ -15764,27 +15769,27 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-beefy",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.3",
@@ -15820,7 +15825,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -15828,7 +15833,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -15841,14 +15846,14 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -15864,14 +15869,14 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15894,7 +15899,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
@@ -15907,7 +15912,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "polkavm 0.9.3",
@@ -15918,7 +15923,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -15936,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "console",
  "futures",
@@ -15947,13 +15952,13 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.3",
@@ -15967,7 +15972,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15989,14 +15994,14 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
  "sp-mixnet",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.45.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.45.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -16033,7 +16038,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -16047,7 +16052,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -16059,13 +16064,13 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ahash 0.8.11",
  "futures",
@@ -16076,7 +16081,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -16084,7 +16089,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -16098,14 +16103,14 @@ dependencies = [
  "sc-network-types",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-network-sync"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -16132,7 +16137,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -16142,7 +16147,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -16164,7 +16169,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
@@ -16174,7 +16179,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.44.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -16186,14 +16191,14 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek 2.1.1",
@@ -16201,7 +16206,7 @@ dependencies = [
  "litep2p",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "rand 0.8.5",
  "thiserror 1.0.69",
  "zeroize",
@@ -16210,14 +16215,14 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "log",
  "num_cpus",
@@ -16236,7 +16241,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-keystore 0.40.0",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "threadpool",
  "tracing",
 ]
@@ -16244,7 +16249,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16253,7 +16258,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "jsonrpsee 0.24.7",
@@ -16275,7 +16280,7 @@ dependencies = [
  "sp-keystore 0.40.0",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-statement-store",
  "sp-version",
@@ -16285,7 +16290,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -16297,23 +16302,23 @@ dependencies = [
  "serde_json",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "17.1.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
  "futures",
  "governor",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "ip_network",
  "jsonrpsee 0.24.7",
  "log",
@@ -16329,7 +16334,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -16351,7 +16356,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-version",
  "thiserror 1.0.69",
  "tokio",
@@ -16361,7 +16366,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "directories",
@@ -16405,7 +16410,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-state-machine 0.43.0",
  "sp-storage 21.0.0",
@@ -16425,7 +16430,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16436,7 +16441,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "clap",
  "fs4",
@@ -16449,7 +16454,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -16461,14 +16466,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "derive_more 0.99.18",
  "futures",
@@ -16489,7 +16494,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "chrono",
  "futures",
@@ -16509,7 +16514,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "chrono",
  "console",
@@ -16527,29 +16532,29 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "thiserror 1.0.69",
  "tracing",
  "tracing-log 0.2.0",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -16566,7 +16571,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
@@ -16576,7 +16581,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
@@ -16585,14 +16590,14 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16719,14 +16724,14 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "scale-info"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -16738,14 +16743,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -16779,9 +16784,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -16873,21 +16878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sctp-proto"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6220f78bb44c15f326b0596113305f6101097a18755d53727a575c97e09fb24"
-dependencies = [
- "bytes",
- "crc",
- "fxhash",
- "log",
- "rand 0.8.5",
- "slab",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16972,9 +16962,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -17004,14 +16994,14 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
@@ -17024,9 +17014,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
@@ -17039,9 +17029,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -17076,22 +17066,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -17192,18 +17182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
- "sha1-asm",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17212,15 +17190,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286acebaf8b67c1130aedffad26f594eff0c1292389158135327d2e23aed582b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -17330,9 +17299,9 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple-dns"
-version = "0.5.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae9a3fcdadafb6d97f4c0e007e4247b114ee0f119f650c3cbf3a8b3a1479694"
+checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -17377,12 +17346,12 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -17624,7 +17593,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -17637,7 +17606,7 @@ dependencies = [
  "snowbridge-milagro-bls",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "ssz_rs",
  "ssz_rs_derive",
@@ -17646,7 +17615,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -17660,7 +17629,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -17669,7 +17638,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -17682,7 +17651,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
@@ -17704,18 +17673,18 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.9.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17728,7 +17697,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17745,7 +17714,7 @@ dependencies = [
  "snowbridge-pallet-ethereum-client-fixtures",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "static_assertions",
 ]
@@ -17753,7 +17722,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17765,7 +17734,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -17784,7 +17753,7 @@ dependencies = [
  "snowbridge-router-primitives",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-executor",
@@ -17793,7 +17762,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -17805,7 +17774,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -17820,14 +17789,14 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17838,7 +17807,7 @@ dependencies = [
  "snowbridge-core",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-executor",
@@ -17847,7 +17816,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-router-primitives"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -17857,7 +17826,7 @@ dependencies = [
  "snowbridge-core",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-executor",
@@ -17866,7 +17835,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "log",
@@ -17881,8 +17850,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.12.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -17904,7 +17873,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -17913,7 +17882,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -17934,9 +17903,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -17954,19 +17923,19 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
 ]
 
 [[package]]
 name = "soketto"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.1.0",
+ "http 1.2.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -17976,7 +17945,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "hash-db",
@@ -17987,7 +17956,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
@@ -17998,7 +17967,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -18006,7 +17975,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -18026,7 +17995,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18053,7 +18022,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -18067,29 +18036,29 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-application-crypto 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -18099,7 +18068,7 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
  "tracing",
@@ -18108,14 +18077,14 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror 1.0.69",
 ]
@@ -18123,7 +18092,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18132,14 +18101,14 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18150,14 +18119,14 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -18170,7 +18139,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "strum 0.26.3",
 ]
@@ -18178,7 +18147,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18189,24 +18158,24 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-consensus-pow"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18262,7 +18231,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "bitflags 1.3.2",
@@ -18323,7 +18292,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-crypto-hashing",
 ]
@@ -18331,7 +18300,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -18351,7 +18320,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18364,17 +18333,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -18388,17 +18357,17 @@ checksum = "c7f531814d2f16995144c74428830ccf7d94ff4a7749632b83ad8199b181140c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -18416,7 +18385,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -18426,25 +18395,25 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -18478,7 +18447,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "docify",
@@ -18504,10 +18473,10 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
@@ -18528,7 +18497,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -18539,7 +18508,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -18548,7 +18517,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -18558,7 +18527,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18569,7 +18538,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18579,31 +18548,31 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-debug-derive 14.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -18620,7 +18589,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -18630,7 +18599,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18662,8 +18631,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "39.0.5"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "either",
@@ -18708,7 +18677,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18734,47 +18703,47 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-staking",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -18801,7 +18770,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hash-db",
  "log",
@@ -18821,7 +18790,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.3",
@@ -18836,7 +18805,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "thiserror 1.0.69",
  "x25519-dalek",
@@ -18851,7 +18820,7 @@ checksum = "53458e3c57df53698b3401ec0934bea8e8cfce034816873c0b0abbd83d7bac0d"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 
 [[package]]
 name = "sp-storage"
@@ -18870,7 +18839,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18882,12 +18851,12 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
 
@@ -18907,34 +18876,34 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
 ]
 
@@ -18965,7 +18934,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -18988,7 +18957,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18996,7 +18965,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "sp-version-proc-macro",
  "thiserror 1.0.69",
@@ -19005,12 +18974,12 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -19030,7 +18999,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -19058,7 +19027,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections 0.2.2",
  "parity-scale-codec",
@@ -19166,7 +19135,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "log",
  "memchr",
  "native-tls",
@@ -19291,7 +19260,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "clap",
  "log",
@@ -19303,7 +19272,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -19313,7 +19282,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-statement-store",
  "thiserror 1.0.69",
 ]
@@ -19321,25 +19290,25 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "staging-tracking-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.2",
@@ -19350,15 +19319,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "xcm-procedural",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "17.0.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -19371,7 +19340,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-executor",
@@ -19380,7 +19349,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -19391,7 +19360,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "tracing",
@@ -19420,35 +19389,15 @@ dependencies = [
 
 [[package]]
 name = "static_init_macro"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
+checksum = "1389c88ddd739ec6d3f8f83343764a0e944cd23cfbf126a9796a714b0b6edd6f"
 dependencies = [
  "cfg_aliases 0.1.1",
  "memchr",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "str0m"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6706347e49b13373f7ddfafad47df7583ed52083d6fc8a594eb2c80497ef959d"
-dependencies = [
- "combine",
- "crc",
- "fastrand 2.2.0",
- "hmac 0.12.1",
- "once_cell",
- "openssl",
- "openssl-sys",
- "sctp-proto",
- "serde",
- "sha-1 0.10.1",
- "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -19515,7 +19464,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -19534,7 +19483,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -19546,12 +19495,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 
 [[package]]
 name = "substrate-frame-rpc-support"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "jsonrpsee 0.24.7",
@@ -19564,7 +19513,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -19578,16 +19527,16 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-util",
  "log",
  "prometheus",
@@ -19598,20 +19547,20 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "jsonrpsee 0.24.7",
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "jsonrpsee 0.24.7",
  "parity-scale-codec",
@@ -19619,7 +19568,7 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
  "trie-db 0.29.1",
@@ -19628,7 +19577,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -19647,7 +19596,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keyring",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "tokio",
 ]
@@ -19655,7 +19604,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-executive",
@@ -19685,7 +19634,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-state-machine 0.43.0",
  "sp-transaction-pool",
@@ -19699,7 +19648,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -19709,7 +19658,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "substrate-test-client",
  "substrate-test-runtime",
 ]
@@ -19717,7 +19666,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "futures",
  "tokio",
@@ -19726,7 +19675,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19820,7 +19769,7 @@ dependencies = [
  "quote",
  "scale-info",
  "subxt-metadata",
- "syn 2.0.87",
+ "syn 2.0.91",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -19851,7 +19800,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro-error",
  "subxt-codegen",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -19880,9 +19829,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -19898,7 +19847,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -19909,9 +19858,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -19936,25 +19885,25 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -19985,9 +19934,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "once_cell",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
@@ -20002,31 +19951,31 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testnet-parachains-constants"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "polkadot-core-primitives",
  "rococo-runtime-constants",
  "smallvec",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "westend-runtime-constants",
 ]
@@ -20042,11 +19991,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -20066,7 +20015,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -20077,18 +20026,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -20163,9 +20112,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -20184,9 +20133,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -20232,9 +20181,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -20247,9 +20196,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -20258,7 +20207,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -20281,7 +20230,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -20307,12 +20256,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.17",
- "rustls-pki-types 1.10.0",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -20330,9 +20278,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -20357,9 +20305,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -20405,7 +20353,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -20427,7 +20375,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -20481,7 +20429,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -20503,9 +20451,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -20515,20 +20463,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -20547,7 +20495,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20558,13 +20506,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -20623,9 +20571,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers 0.1.0",
  "nu-ansi-term",
@@ -20635,7 +20583,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.36",
+ "time 0.3.37",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
@@ -20845,15 +20793,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -20940,9 +20888,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",
@@ -21096,9 +21044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -21107,36 +21055,36 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -21144,22 +21092,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-instrument"
@@ -21260,7 +21208,7 @@ checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
 dependencies = [
  "arrayvec 0.7.6",
  "multi-stash",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "smallvec",
  "spin 0.9.8",
@@ -21538,9 +21486,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -21574,17 +21522,17 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
 ]
 
 [[package]]
 name = "westend-runtime"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21675,7 +21623,7 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking",
  "sp-storage 21.0.0",
@@ -21692,14 +21640,14 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -21714,14 +21662,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.40",
+ "rustix 0.38.42",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.28"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+checksum = "58e6db2670d2be78525979e9a5f9c69d296fd7d670549fe9ebf70f8708cb5019"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -21766,21 +21714,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.51.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-core 0.53.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -21793,13 +21732,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -21818,23 +21776,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -22128,7 +22071,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -22145,24 +22088,24 @@ dependencies = [
  "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.4.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22176,7 +22119,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -22188,7 +22131,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.1",
+ "sp-runtime 39.0.5",
  "sp-std 14.0.0",
  "staging-xcm",
  "staging-xcm-builder",
@@ -22197,9 +22140,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
+checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "xmltree"
@@ -22221,30 +22164,30 @@ dependencies = [
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4b418619005a69b15fbb3832eb974440a3b4d14639d08211af0e307f90440c"
+checksum = "e920f850fe9664dcc21f3f0c2b578b8a7e751e6bf7f9b7e32f0dcef22e273f71"
 dependencies = [
  "log",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "xous",
- "xous-ipc 0.10.2",
+ "xous-ipc 0.10.4",
 ]
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe645ec314e1d233a9a97ecd84d3f7b9500b5726eb429af13d7a11f36ec5df7"
+checksum = "f8a98dbd12e316cf0075619ec68fc63e354dc23aa05f6b2268a63a5c3bd85760"
 dependencies = [
  "log",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
- "rkyv 0.8.8",
+ "rkyv 0.8.9",
  "xous",
  "xous-api-log",
- "xous-ipc 0.10.2",
+ "xous-ipc 0.10.4",
 ]
 
 [[package]]
@@ -22260,12 +22203,12 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696ba6ec9c5cc8218f55d8a04ae7ef9311ed0ec92699f4d509317883ad04769a"
+checksum = "b3caa39ab85d4a61827f8e5682cadb667b4eff013f3ae2c05311b48604b9be1c"
 dependencies = [
  "bitflags 1.3.2",
- "rkyv 0.8.8",
+ "rkyv 0.8.9",
  "xous",
 ]
 
@@ -22302,14 +22245,14 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -22319,13 +22262,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -22347,27 +22290,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -22388,7 +22331,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -22410,7 +22353,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,198 +92,198 @@ repository = "https://github.com/CESSProject/cess"
 [workspace.dependencies]
 # ---- Substrate crates begin ----
 #	primitives
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-application-crypto = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-npos-elections = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-statement-store = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-tracing = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-transaction-storage-proof = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-trie = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-application-crypto = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-authority-discovery = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-block-builder = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-blockchain = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sp-consensus = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-consensus-babe = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-consensus-slots = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-core = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-externalities = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-genesis-builder = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-inherents = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-io = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-keyring = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sp-keystore = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-npos-elections = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-offchain = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-runtime = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-runtime-interface = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-session = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-staking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-state-machine = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-statement-store = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-std = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-storage = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-timestamp = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-tracing = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-transaction-pool = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-transaction-storage-proof = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-trie = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-version = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+sp-consensus-aura = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
 
 #	frames
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-election-provider-support = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-frame-support-test = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
+frame-support = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-system = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-executive = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-election-provider-support = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-try-runtime = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+frame-support-test = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
 
 #	pallets
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-asset-rate = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-asset-tx-payment = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-asset-conversion = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-asset-conversion-tx-payment = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-uniques = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-preimage = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-beefy = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-beefy-mmr = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-transaction-storage = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-authorship = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-babe = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-bags-list = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-bounties = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-child-bounties = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-elections-phragmen = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-election-provider-multi-phase = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-election-provider-support-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-fast-unstake = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-indices = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-identity = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-lottery = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-membership = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-mmr = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-migrations = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-nomination-pools = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-nomination-pools-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-offences = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-offences-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-recovery = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-session = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false, features = [
+pallet-assets = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-asset-rate = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-asset-tx-payment = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-asset-conversion = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-asset-conversion-tx-payment = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-aura = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-democracy = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-uniques = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-preimage = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-balances = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-beefy = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-beefy-mmr = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-timestamp = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-scheduler = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-collective = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-contracts = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-im-online = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-sudo = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-treasury = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-transaction-storage = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-authorship = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-babe = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-bags-list = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-bounties = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-child-bounties = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-elections-phragmen = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-election-provider-support-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-grandpa = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-indices = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-identity = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-lottery = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-membership = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-multisig = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-mmr = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-migrations = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-nomination-pools-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-offences = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-offences-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-proxy = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-recovery = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-session = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false, features = [
     "historical",
 ] }
-pallet-session-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-state-trie-migration = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-society = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-tips = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-vesting = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-pallet-parameters = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-session-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-staking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-state-trie-migration = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-society = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-tips = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-utility = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-vesting = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+pallet-parameters = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
 
 #   client dependencies
-grandpa = { package = "sc-consensus-grandpa", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-block-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-client-db = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-babe-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-epochs = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-grandpa-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-keystore = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-network-statement = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-network-test = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-rpc-spec-v2 = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-service-test = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-statement-store = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-storage-monitor = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-sync-state-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-sysinfo = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
+grandpa = { package = "sc-consensus-grandpa", git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-authority-discovery = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-basic-authorship = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-block-builder = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-chain-spec = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-cli = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-client-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-client-db = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-babe = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-babe-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-epochs = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-grandpa = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-grandpa-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-manual-seal = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-consensus-slots = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-executor = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-keystore = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-network = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-network-common = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-network-sync = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-network-statement = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-network-test = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-offchain = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-rpc-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-rpc-spec-v2 = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-service = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-service-test = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-statement-store = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-storage-monitor = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-sync-state-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-sysinfo = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-telemetry = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-transaction-pool = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sc-transaction-pool-api = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
 
-substrate-state-trie-migration-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-node-inspect = { package = "staging-node-inspect", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
-try-runtime-cli = { git = "https://github.com/paritytech/try-runtime-cli.git", tag = "v0.8.0", default-features = false }
-substrate-frame-cli = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-rpc-client = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-mmr-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-test-utils = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-fork-tree = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-wasm-builder = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+node-inspect = { package = "staging-node-inspect", git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
+try-runtime-cli = { git = "https://github.com/CESSProject/try-runtime-cli.git", branch = "stable2409", default-features = false }
+substrate-frame-cli = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-build-script-utils = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-rpc-client = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-frame-rpc-system = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+mmr-rpc = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-test-utils = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+fork-tree = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+substrate-test-runtime-client = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
 
-polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409", default-features = false }
+polkadot-sdk = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409", default-features = false }
 # ---- Substrate crates end ----
 
 # ---- Frontier crates begin ----
-fp-account = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fp-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fp-rpc = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fp-self-contained = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
+fp-account = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fp-evm = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fp-rpc = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fp-self-contained = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
 
-pallet-base-fee = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-ethereum = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-evm = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
+pallet-base-fee = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-ethereum = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-evm = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
 
-fc-api = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f" }
-fc-cli = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-consensus = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-db = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-mapping-sync = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-rpc = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-rpc-core = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
-fc-storage = { git = "https://github.com/polkadot-evm/frontier", rev = "18aa99b365d32a1524b4e7591f3797378c11fb0f", default-features = false }
+fc-api = { git = "https://github.com/CESSProject/frontier", branch = "stable2409" }
+fc-cli = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-consensus = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-db = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-mapping-sync = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-rpc = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-rpc-core = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
+fc-storage = { git = "https://github.com/CESSProject/frontier", branch = "stable2409", default-features = false }
 # ---- Frontier crates end ----
 
 # ---- Generic crates begin ----
@@ -474,8 +474,8 @@ cess-node-primitives = { path = "standalone/chain/primitives", default-features 
 [patch.crates-io]
 ring = { git = "https://github.com/jasl/ring-xous", branch = "better-wasm32-support" }
 
-sp-application-crypto = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "stable2409" }
+sp-application-crypto = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sp-core = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sp-runtime = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+sp-externalities = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }
+frame-benchmarking = { git = "https://github.com/CESSProject/polkadot-sdk.git", branch = "stable2409" }

--- a/standalone/chain/node/Cargo.toml
+++ b/standalone/chain/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Unlicense'
 name = 'cess-node'
 repository = 'https://github.com/CESSProject/cess'
-version = '0.8.0'
+version = '0.8.1'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/standalone/chain/runtime/src/frontier.rs
+++ b/standalone/chain/runtime/src/frontier.rs
@@ -33,10 +33,13 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 
 const BLOCK_GAS_LIMIT: u64 = 75_000_000;
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+/// The maximum storage growth per block in bytes.
+const MAX_STORAGE_GROWTH: u64 = 400 * 1024;
 
 parameter_types! {
 	pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
 	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	pub const GasLimitStorageGrowthRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_STORAGE_GROWTH);
 	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
 	pub WeightPerGas: Weight = Weight::from_parts(weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK), 0);
 	pub SuicideQuickClearLimit: u32 = 0;
@@ -63,6 +66,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = FindAuthorTruncated<Babe>;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
 	type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Self>;
 }

--- a/standalone/teeworker/ceseal/Cargo.lock
+++ b/standalone/teeworker/ceseal/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-primitives"
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -172,7 +172,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "approx"
@@ -264,7 +264,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -618,14 +618,15 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-test-utils"
-version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "20.0.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
+ "pallet-asset-conversion",
  "pallet-assets",
  "pallet-balances",
  "pallet-collator-selection",
@@ -643,12 +644,13 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "assets-common"
-version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -676,7 +678,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -693,7 +695,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -715,7 +717,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -757,7 +759,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.5",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -794,9 +796,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
@@ -808,7 +810,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hash-db",
  "log",
@@ -941,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -958,7 +960,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -974,7 +976,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -991,7 +993,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1004,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1022,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1040,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1063,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1082,8 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.4.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1100,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1112,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1128,8 +1130,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.20.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1171,8 +1173,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1232,9 +1234,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -1244,9 +1246,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "camino"
@@ -1259,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -1274,7 +1276,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.24",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1282,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "jobserver",
  "libc",
@@ -1397,7 +1399,7 @@ dependencies = [
 name = "ces-sanitized-logger"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.11.5",
+ "env_logger 0.11.6",
  "log",
  "tracing-core",
  "tracing-subscriber",
@@ -1582,7 +1584,7 @@ dependencies = [
  "finality-grandpa",
  "frame-system",
  "glob",
- "h2 0.4.6",
+ "h2 0.4.7",
  "hash-db",
  "hex",
  "hex-literal",
@@ -1690,9 +1692,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "num-traits",
  "serde",
@@ -1710,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1720,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1739,14 +1741,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmac"
@@ -1766,7 +1768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1783,22 +1785,22 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "const-hex"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1850,7 +1852,7 @@ checksum = "3d3007177ccd2435eef6de9e7471365c36bc35c0b31773e27b4fe797f39f84bf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1917,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -2033,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2052,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -2107,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2124,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2141,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2177,18 +2179,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2201,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2216,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2231,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2256,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -2271,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2280,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2296,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2310,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2320,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2336,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2346,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2363,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2397,51 +2399,66 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c042a0ba58aaff55299632834d1ea53ceff73d62373f62c9ae60890ad1b942"
+checksum = "4d44ff199ff93242c3afe480ab588d544dd08d72e92885e152ffebc670f076ad"
 dependencies = [
  "cc",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dc1c88d0fdac57518a9b1f6c4f4fb2aca8f3c30c0d03d7d8518b47ca0bcea6"
+checksum = "66fd8f17ad454fc1e4f4ab83abffcc88a532e90350d3ffddcb73030220fcbd52"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.87",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4717c9c806a9e07fdcb34c84965a414ea40fafe57667187052cf1eb7f5e8a8a9"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7ed7d30b289e2592cc55bc2ccd89803a63c913e008e6eb59f06cddf45bb52f"
+checksum = "2f6515329bf3d98f4073101c7866ff2bec4e635a13acb82e3f3753fff0bf43cb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.130"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c465d22de46b851c04630a5fc749a26005b263632ed2e0d9cc81518ead78d"
+checksum = "fb93e6a7ce8ec985c02bbb758237a31598b340acbbc3c19c5a4fa6adaaac92ab"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2503,7 +2520,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2534,7 +2551,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2547,7 +2564,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2567,7 +2584,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "unicode-xid",
 ]
 
@@ -2621,7 +2638,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2645,7 +2662,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.91",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
@@ -2772,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-as-inner"
@@ -2785,7 +2802,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2805,7 +2822,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2816,14 +2833,14 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -2844,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2869,12 +2886,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3020,7 +3037,7 @@ dependencies = [
  "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3037,15 +3054,26 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -3147,6 +3175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "hex",
  "impl-serde",
@@ -3177,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -3188,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -3198,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3210,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "evm",
  "frame-support",
@@ -3225,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -3241,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3253,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3262,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3286,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3300,18 +3334,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3327,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3357,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes",
  "docify",
@@ -3371,8 +3405,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3413,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3427,35 +3461,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3475,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3489,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3499,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3585,7 +3619,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3739,7 +3773,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3748,17 +3782,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.6.0",
+ "http 1.2.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3816,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -3870,9 +3904,9 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3881,7 +3915,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.4.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand 0.8.5",
@@ -3894,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3954,11 +3988,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3985,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -4012,7 +4046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -4023,7 +4057,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -4048,9 +4082,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4072,14 +4106,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -4091,16 +4125,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.0",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4113,7 +4147,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -4128,9 +4162,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4253,17 +4287,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4342,13 +4366,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4383,12 +4407,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -4490,9 +4514,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -4505,10 +4529,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -4546,9 +4571,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -4653,9 +4678,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -4709,7 +4734,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4723,7 +4748,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4734,7 +4759,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4745,7 +4770,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4791,7 +4816,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.40",
+ "rustix 0.38.42",
 ]
 
 [[package]]
@@ -4847,20 +4872,19 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
@@ -4895,7 +4919,7 @@ checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4988,24 +5012,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5087,7 +5100,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5122,9 +5135,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -5150,7 +5163,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5169,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5187,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5205,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5219,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5233,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5250,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5266,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5281,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5325,7 +5338,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5341,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5356,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5369,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5392,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aquamarine",
  "docify",
@@ -5413,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5428,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -5442,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5461,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5486,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5503,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5522,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5541,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -5560,8 +5573,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.18.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5584,8 +5597,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.17.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -5654,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5672,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5691,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5707,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5721,7 +5734,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -5753,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5788,17 +5801,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -5810,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5825,8 +5838,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "22.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5844,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5859,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5876,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5891,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-dynamic-fee",
  "fp-evm",
@@ -5906,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5928,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5941,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5959,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -5982,7 +5995,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "environmental",
  "evm",
@@ -6024,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6035,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "num",
@@ -6044,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -6053,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/polkadot-evm/frontier?rev=18aa99b365d32a1524b4e7591f3797378c11fb0f#18aa99b365d32a1524b4e7591f3797378c11fb0f"
+source = "git+https://github.com/CESSProject/frontier?branch=stable2409#d2b9fd25a6a9b8dd90dbeaf0dbf1e7dda55a9ab8"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -6063,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6110,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -6128,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6150,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6166,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6185,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6201,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6214,7 +6227,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6227,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6243,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -6262,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6279,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6298,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6315,7 +6328,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6330,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6346,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6363,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -6373,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6388,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6402,8 +6415,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "35.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6421,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6440,8 +6453,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "33.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6451,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6467,7 +6480,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6509,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6526,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6543,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6559,7 +6572,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6572,8 +6585,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6591,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6605,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6622,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6651,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -6681,7 +6694,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "frame-system",
@@ -6695,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-mock-network"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6729,17 +6742,17 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6751,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6766,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6805,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6822,8 +6835,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-salary"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "23.2.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6841,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6874,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6887,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6908,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6924,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6967,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6984,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7005,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -7014,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7024,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7040,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7076,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7117,7 +7130,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7136,7 +7149,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7153,8 +7166,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "38.0.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7169,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7181,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7200,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7218,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7235,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7249,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7264,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7278,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7292,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7316,7 +7329,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7333,8 +7346,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.13.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -7355,8 +7368,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.15.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -7375,7 +7388,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -7404,8 +7417,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "19.0.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -7419,6 +7432,7 @@ dependencies = [
  "pallet-session",
  "pallet-timestamp",
  "pallet-xcm",
+ "parachains-common",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-consensus-aura",
@@ -7430,6 +7444,7 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "xcm-runtime-apis",
 ]
 
 [[package]]
@@ -7590,12 +7605,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "ucd-trie",
 ]
 
@@ -7606,7 +7621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -7626,7 +7641,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7702,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7713,7 +7728,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -7729,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -7755,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7804,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7816,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -7863,8 +7878,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.9.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -8095,7 +8110,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8214,7 +8229,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8226,7 +8241,7 @@ dependencies = [
  "polkavm-common 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8236,7 +8251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8246,7 +8261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9324fe036de37c17829af233b46ef6b5562d4a0c09bb7fdb9f8378856dee30cf"
 dependencies = [
  "polkavm-derive-impl 0.10.0",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8273,7 +8288,7 @@ dependencies = [
  "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "object 0.36.5",
+ "object 0.36.7",
  "polkavm-common 0.10.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
@@ -8335,7 +8350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8394,14 +8409,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -8526,7 +8541,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8545,10 +8560,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -8563,11 +8578,11 @@ dependencies = [
  "getrandom",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "rustls",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8575,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -8734,9 +8749,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -8769,7 +8784,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -8859,10 +8874,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hickory-resolver",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.2",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -8875,11 +8890,11 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pemfile",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -8974,18 +8989,18 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
+checksum = "b11a153aec4a6ab60795f8ebe2923c597b16b05bb1504377451e705ef1a45323"
 dependencies = [
  "bytes",
- "hashbrown 0.14.5",
- "indexmap 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
  "rend",
- "rkyv_derive 0.8.8",
+ "rkyv_derive 0.8.9",
  "tinyvec",
  "uuid",
 ]
@@ -9003,13 +9018,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
+checksum = "beb382a4d9f53bd5c0be86b10d8179c3f8a14c30bf774ff77096ed6581e35981"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -9037,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9072,16 +9087,18 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -9127,9 +9144,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc-hex"
@@ -9167,7 +9184,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.24",
 ]
 
 [[package]]
@@ -9186,26 +9203,26 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
@@ -9217,7 +9234,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
 ]
 
 [[package]]
@@ -9228,9 +9245,9 @@ checksum = "a47003264dea418db67060fa420ad16d0d2f8f0a0360d825c00e177ac52cb5d8"
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -9252,7 +9269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
  "untrusted 0.9.0",
 ]
 
@@ -9291,9 +9308,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3460605018fdc9612bce72735cba0d27efbcd9904780d44c7e3a9948f96148a"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -9310,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "sp-core",
@@ -9321,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -9344,7 +9361,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
@@ -9357,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "polkavm 0.9.3",
@@ -9368,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -9385,9 +9402,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9399,14 +9416,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -9517,14 +9534,14 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 dependencies = [
  "serde",
 ]
@@ -9537,18 +9554,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -9583,22 +9600,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -9788,7 +9805,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -9815,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -9837,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -9860,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -9895,7 +9912,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.9.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9906,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -9919,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9943,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -9955,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -9982,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -9994,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -10016,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10036,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-router-primitives"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -10055,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "log",
@@ -10070,8 +10087,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.12.0"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -10102,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -10113,9 +10130,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -10124,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "hash-db",
@@ -10146,7 +10163,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "blake2",
@@ -10154,13 +10171,13 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10172,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -10186,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10198,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -10208,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10224,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10242,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -10263,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10280,7 +10297,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10291,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10302,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -10348,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-crypto-hashing",
 ]
@@ -10356,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -10376,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -10389,27 +10406,27 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10419,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10431,7 +10448,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10444,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "docify",
@@ -10470,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -10480,7 +10497,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -10491,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -10500,7 +10517,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -10510,7 +10527,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10521,7 +10538,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10538,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10551,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10561,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -10570,8 +10587,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "39.0.5"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "docify",
  "either",
@@ -10597,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10616,20 +10633,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10643,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10656,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hash-db",
  "log",
@@ -10676,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -10700,12 +10717,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10717,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10729,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -10740,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10749,7 +10766,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10763,7 +10780,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -10786,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10803,18 +10820,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10826,7 +10843,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10916,7 +10933,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10929,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -10947,8 +10964,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "17.0.3"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10970,7 +10987,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -11048,13 +11065,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -11066,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -11102,9 +11119,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11120,7 +11137,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -11131,9 +11148,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -11158,7 +11175,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -11182,7 +11199,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix 0.38.40",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
@@ -11198,7 +11215,7 @@ dependencies = [
 [[package]]
 name = "testnet-parachains-constants"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -11221,11 +11238,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -11236,18 +11253,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -11282,9 +11299,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -11305,9 +11322,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11334,9 +11351,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -11349,9 +11366,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11383,17 +11400,16 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types 1.10.0",
  "tokio",
 ]
 
@@ -11411,9 +11427,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -11422,9 +11438,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -11469,7 +11485,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -11491,7 +11507,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -11551,9 +11567,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -11563,20 +11579,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11595,9 +11611,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -11606,7 +11622,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.36",
+ "time 0.3.37",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -11694,16 +11710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -11719,6 +11729,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -11750,12 +11766,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
 ]
 
@@ -11804,7 +11820,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "rustversion",
- "time 0.3.36",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -11879,9 +11895,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -11890,36 +11906,36 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11927,22 +11943,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-instrument"
@@ -12001,7 +12017,7 @@ checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
 dependencies = [
  "arrayvec",
  "multi-stash",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "smallvec",
  "spin 0.9.8",
@@ -12249,9 +12265,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12269,17 +12285,17 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
- "rustls-pki-types 1.10.0",
+ "rustls-pki-types 1.10.1",
 ]
 
 [[package]]
 name = "westend-runtime-constants"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12301,14 +12317,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.40",
+ "rustix 0.38.42",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.28"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+checksum = "58e6db2670d2be78525979e9a5f9c69d296fd7d670549fe9ebf70f8708cb5019"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -12661,18 +12677,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+version = "0.4.2"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -12686,7 +12702,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=stable2409#dba2dd59101617aad64d167e400b19e2c35052b1"
+source = "git+https://github.com/CESSProject/polkadot-sdk.git?branch=stable2409#0605ce24774311081346e1ca375e18807eaaec2f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12716,30 +12732,30 @@ dependencies = [
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4b418619005a69b15fbb3832eb974440a3b4d14639d08211af0e307f90440c"
+checksum = "e920f850fe9664dcc21f3f0c2b578b8a7e751e6bf7f9b7e32f0dcef22e273f71"
 dependencies = [
  "log",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "xous",
- "xous-ipc 0.10.2",
+ "xous-ipc 0.10.4",
 ]
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe645ec314e1d233a9a97ecd84d3f7b9500b5726eb429af13d7a11f36ec5df7"
+checksum = "f8a98dbd12e316cf0075619ec68fc63e354dc23aa05f6b2268a63a5c3bd85760"
 dependencies = [
  "log",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
- "rkyv 0.8.8",
+ "rkyv 0.8.9",
  "xous",
  "xous-api-log",
- "xous-ipc 0.10.2",
+ "xous-ipc 0.10.4",
 ]
 
 [[package]]
@@ -12755,20 +12771,20 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696ba6ec9c5cc8218f55d8a04ae7ef9311ed0ec92699f4d509317883ad04769a"
+checksum = "b3caa39ab85d4a61827f8e5682cadb667b4eff013f3ae2c05311b48604b9be1c"
 dependencies = [
  "bitflags 1.3.2",
- "rkyv 0.8.8",
+ "rkyv 0.8.9",
  "xous",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -12778,13 +12794,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -12806,27 +12822,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
  "synstructure 0.13.1",
 ]
 
@@ -12847,7 +12863,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -12869,7 +12885,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.91",
 ]
 
 [[package]]


### PR DESCRIPTION
[PR #5998](https://github.com/paritytech/polkadot-sdk/pull/5998) in the official Polkadot repository addresses this memory leak issue, but it has not been adopted because it constitutes a major change for the `stable2409` branch.

closes #423 