### PR TITLE
Bump some artifact versions as the major update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "cess-node"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "cifrost"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "handover"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "tokio",

--- a/pallets/file-bank/src/functions.rs
+++ b/pallets/file-bank/src/functions.rs
@@ -332,6 +332,8 @@ impl<T: Config> Pallet<T> {
         false
     }
 
+    // FIXME: Will this function still be used?
+    #[allow(dead_code)]
     pub(super) fn check_name_spec(name: Vec<u8>) -> bool {
         let mut point_flag: bool = false;
         let mut count = 0;

--- a/pallets/file-bank/src/lib.rs
+++ b/pallets/file-bank/src/lib.rs
@@ -54,7 +54,7 @@ use frame_support::{
 	PalletId, 
 	dispatch::DispatchResult, 
 	pallet_prelude::*,
-	weights::{Weight, WeightMeter},
+	weights::Weight,
 };
 use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;

--- a/pallets/file-bank/src/migration.rs
+++ b/pallets/file-bank/src/migration.rs
@@ -1,13 +1,17 @@
 use super::*;
-use sp_std::collections::btree_map::BTreeMap;
-use sp_runtime::{TryRuntimeError};
 use frame_support::{
-	storage_alias, weights::WeightMeter,
+	storage_alias,
 	migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
 };
 
 #[cfg(feature = "try-runtime")]
 use sp_runtime::Vec;
+#[cfg(feature = "try-runtime")]
+use sp_std::collections::btree_map::BTreeMap;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::{TryRuntimeError};
+#[cfg(feature = "try-runtime")]
+use frame_support::weights::WeightMeter;
 
 pub const PALLET_MIGRATIONS_ID: &[u8; 26] = b"pallet-file-bank-migration";
 

--- a/pallets/sminer/src/lib.rs
+++ b/pallets/sminer/src/lib.rs
@@ -23,7 +23,7 @@ use cp_bloom_filter::BloomFilter;
 use cp_cess_common::*;
 use frame_support::{
 	dispatch::DispatchResult,
-	ensure, weights::{Weight, WeightMeter},
+	ensure, weights::Weight,
 	pallet_prelude::DispatchError,
 	storage::bounded_vec::BoundedVec,
 	traits::{

--- a/pallets/sminer/src/migration.rs
+++ b/pallets/sminer/src/migration.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(feature = "try-runtime")]
 use sp_runtime::{TryRuntimeError};
 #[cfg(feature = "try-runtime")]
 use sp_std::collections::btree_map::BTreeMap;
@@ -110,7 +111,7 @@ impl<T: Config, W: weights::WeightInfo> SteppedMigration for SteppedSminer<T, W>
 }
 
 pub mod v2 {
-	use super::{*, MinerItems as NewMinerItems};
+	use super::*;
 
 	#[storage_alias]
 	pub type MinerItems<T: Config> = StorageMap<Pallet<T>, Blake2_128Concat, AccountOf<T>, OldMinerInfo<T>>;

--- a/standalone/chain/node/Cargo.toml
+++ b/standalone/chain/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2021'
 license = 'Unlicense'
 name = 'cess-node'
 repository = 'https://github.com/CESSProject/cess'
-version = '0.8.2'
+version = '0.9.0'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/standalone/teeworker/ceseal/Cargo.lock
+++ b/standalone/teeworker/ceseal/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "ceseal"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "cess-node-runtime"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ces-pallet-mq",
  "ces-pallet-mq-runtime-api",
@@ -6801,6 +6801,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
+ "impl-trait-for-tuples",
  "log",
  "pallet-balances",
  "pallet-cess-staking",

--- a/standalone/teeworker/ceseal/Cargo.toml
+++ b/standalone/teeworker/ceseal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "ceseal"
-version = "0.3.4"
+version = "0.4.0"
 build = "build.rs"
 
 [profile.release]

--- a/standalone/teeworker/cifrost/Cargo.toml
+++ b/standalone/teeworker/cifrost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cifrost"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["CESS Network"]
 edition = "2021"
 

--- a/standalone/teeworker/handover/Cargo.toml
+++ b/standalone/teeworker/handover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "handover"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- bump `cess-node` `ceseal` `cifrost` `handover` versions;
- fix compile warnings on `default` and `try-runtime` features