### PR TITLE
fix: fix reactivate_territory func

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "cess-node-runtime"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ces-pallet-mq",
  "ces-pallet-mq-runtime-api",

--- a/pallets/storage-handler/src/lib.rs
+++ b/pallets/storage-handler/src/lib.rs
@@ -986,8 +986,7 @@ pub mod pallet {
         pub fn fix_territory_space_for_reactivate(origin: OriginFor<T>, acc: AccountOf<T>, tname: TerrName) -> DispatchResult {
             let _ = ensure_root(origin)?;
 
-            let territory = <Territory<T>>::try_get(&acc, &tname).map_err(|_| Error::<T>::NotHaveTerritory)?;
-            let mut territory = territory.as_mut().ok_or(Error::<T>::NotHaveTerritory)?;
+            let mut territory = <Territory<T>>::try_get(&acc, &tname).map_err(|_| Error::<T>::NotHaveTerritory)?;
             territory.remaining_space = territory.total_space;
             <Territory<T>>::insert(&acc, &tname, territory);
 

--- a/standalone/chain/runtime/Cargo.toml
+++ b/standalone/chain/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "Unlicense"
 name = "cess-node-runtime"
 repository = "https://github.com/CESSProject/cess"
-version = "0.10.0"
+version = "0.10.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/standalone/chain/runtime/src/lib.rs
+++ b/standalone/chain/runtime/src/lib.rs
@@ -155,7 +155,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 129,
+	spec_version: 130,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
@tehsunnliu pointed out that when a territory expires and is reactivated, the remaining space of the territory is still 0.

This PR is to fix the above bug and provide a root permission method to repair data.